### PR TITLE
fix: relinquish control of DontShowIconsInMenus

### DIFF
--- a/gui/application_mac.cpp
+++ b/gui/application_mac.cpp
@@ -30,7 +30,7 @@
 Application::Application(int& argc, char** argv)
 	: SingleApplication(argc, argv)
 {
-	setAttribute(Qt::AA_DontShowIconsInMenus, true);
+	setAttribute(Qt::AA_DontShowIconsInMenus, false);
 
 	// Set DYLD_LIBRARY_PATH so that Qt finds our openSSL libs
 	QDir dir(argv[0]);

--- a/gui/application_qt.cpp
+++ b/gui/application_qt.cpp
@@ -40,9 +40,6 @@ bool Application::start(const QStringList& files)
 {
 	// TODO: Add an option to try to run anyway when DBUS binding fails.
 	if (QDBusConnection::sessionBus().registerService(PROJECT_REV_ID)) {
-		if (Utils::KDE != Utils::currentDe()) {
-			setAttribute(Qt::AA_DontShowIconsInMenus, true);
-		}
 		return true;
 	}
 	loadFiles(files);

--- a/gui/application_win.cpp
+++ b/gui/application_win.cpp
@@ -29,7 +29,7 @@ Application::Application(int& argc, char** argv)
 	: SingleApplication(argc, argv)
 {
 	installNativeEventFilter(this);
-	setAttribute(Qt::AA_DontShowIconsInMenus, true);
+	setAttribute(Qt::AA_DontShowIconsInMenus, false);
 }
 
 bool Application::nativeEventFilter(const QByteArray&, void* message, qintptr* result)

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -199,7 +199,6 @@ MainWindow::MainWindow(QWidget* parent)
 	setWindowTitle("Cantata");
 	QWidget* tb = toolbar;
 #ifdef Q_OS_MAC
-	qApp->setAttribute(Qt::AA_DontShowIconsInMenus, false);
 	setUnifiedTitleAndToolBarOnMac(true);
 	QToolBar* topToolBar = addToolBar("ToolBar");
 	WindowManager* wm = new WindowManager(topToolBar);

--- a/support/shortcutsmodel.cpp
+++ b/support/shortcutsmodel.cpp
@@ -28,7 +28,6 @@ ShortcutsModel::ShortcutsModel(const QHash<QString, ActionCollection*>& actionCo
 	: QAbstractItemModel(parent),
 	  _changedCount(0)
 {
-	_showIcons = !QCoreApplication::testAttribute(Qt::AA_DontShowIconsInMenus);
 	for (int r = 0; r < actionCollections.values().count(); r++) {
 		ActionCollection* coll = actionCollections.values().at(r);
 		Item* item = new Item();
@@ -158,7 +157,7 @@ QVariant ShortcutsModel::data(const QModelIndex& index, int role) const
 		}
 
 	case Qt::DecorationRole:
-		if (index.column() == 0 && _showIcons)
+		if (index.column() == 0 && !QCoreApplication::testAttribute(Qt::AA_DontShowIconsInMenus))
 			return action->icon();
 		return QVariant();
 

--- a/support/shortcutsmodel.h
+++ b/support/shortcutsmodel.h
@@ -91,7 +91,6 @@ private:
 
 	QList<Item*> _categoryItems;
 	int _changedCount;
-	bool _showIcons;
 };
 
 #endif// SHORTCUTSMODEL_H


### PR DESCRIPTION
No need to force it except on platforms without many QPA plugins like Mac & Windows.

Fixes part of #16.