### PR TITLE
fix: GUI responsiveness when changing tracks

### DIFF
--- a/3rdparty/knotifications/src/knotification.cpp
+++ b/3rdparty/knotifications/src/knotification.cpp
@@ -171,15 +171,15 @@ QString KNotification::iconName() const
 	return d->iconName;
 }
 
-QPixmap KNotification::pixmap() const
+const QImage& KNotification::image() const
 {
-	return d->pixmap;
+	return d->image;
 }
 
-void KNotification::setPixmap(const QPixmap& pix)
+void KNotification::setImage(const QImage& img)
 {
 	d->needUpdate = true;
-	d->pixmap = pix;
+	d->image = img;
 	if (d->id >= 0) {
 		d->updateTimer.start();
 	}
@@ -416,14 +416,14 @@ static QString defaultComponentName()
 KNotification* KNotification::event(const QString& eventid,
                                     const QString& title,
                                     const QString& text,
-                                    const QPixmap& pixmap,
+                                    const QImage& image,
                                     const NotificationFlags& flags,
                                     const QString& componentName)
 {
 	KNotification* notify = new KNotification(eventid, flags);
 	notify->setTitle(title);
 	notify->setText(text);
-	notify->setPixmap(pixmap);
+	notify->setImage(image);
 	notify->setComponentName((flags & DefaultEvent) ? defaultComponentName() : componentName);
 
 	QTimer::singleShot(0, notify, &KNotification::sendEvent);
@@ -432,19 +432,19 @@ KNotification* KNotification::event(const QString& eventid,
 }
 
 KNotification*
-KNotification::event(const QString& eventid, const QString& text, const QPixmap& pixmap, const NotificationFlags& flags, const QString& componentName)
+KNotification::event(const QString& eventid, const QString& text, const QImage& image, const NotificationFlags& flags, const QString& componentName)
 {
-	return event(eventid, QString(), text, pixmap, flags, componentName);
+	return event(eventid, QString(), text, image, flags, componentName);
 }
 
-KNotification* KNotification::event(StandardEvent eventid, const QString& title, const QString& text, const QPixmap& pixmap, const NotificationFlags& flags)
+KNotification* KNotification::event(StandardEvent eventid, const QString& title, const QString& text, const QImage& image, const NotificationFlags& flags)
 {
-	return event(standardEventToEventId(eventid), title, text, pixmap, flags | DefaultEvent);
+	return event(standardEventToEventId(eventid), title, text, image, flags | DefaultEvent);
 }
 
-KNotification* KNotification::event(StandardEvent eventid, const QString& text, const QPixmap& pixmap, const NotificationFlags& flags)
+KNotification* KNotification::event(StandardEvent eventid, const QString& text, const QImage& image, const NotificationFlags& flags)
 {
-	return event(eventid, QString(), text, pixmap, flags);
+	return event(eventid, QString(), text, image, flags);
 }
 
 KNotification* KNotification::event(const QString& eventid,
@@ -491,7 +491,7 @@ void KNotification::deref()
 
 void KNotification::beep(const QString& reason)
 {
-	event(QStringLiteral("beep"), reason, QPixmap(), CloseOnTimeout | DefaultEvent);
+	event(QStringLiteral("beep"), reason, QImage(), CloseOnTimeout | DefaultEvent);
 }
 
 void KNotification::sendEvent()

--- a/3rdparty/knotifications/src/knotification.h
+++ b/3rdparty/knotifications/src/knotification.h
@@ -12,7 +12,7 @@
 #include <QList>
 #include <QObject>
 #include <QPair>
-#include <QPixmap>
+#include <QImage>
 #include <QUrl>
 #include <QVariant>
 #include <QWindow>
@@ -302,16 +302,16 @@ public:
 	void setIconName(const QString& icon);
 
 	/**
-     * \return the pixmap shown in the popup
-     * \see setPixmap
+     * \return the image shown in the popup
+     * \see setImage
      */
-	QPixmap pixmap() const;
+	const QImage& image() const;
 	/**
-     * Set the pixmap that will be shown in the popup. If you want to use an icon from the icon theme use setIconName instead.
+     * Set the image that will be shown in the popup. If you want to use an icon from the icon theme use setIconName instead.
      *
-     * @param pix the pixmap
+     * @param img the image
      */
-	void setPixmap(const QPixmap& pix);
+	void setImage(const QImage& img);
 
 	/**
      * @return the default action, or nullptr if none is set
@@ -690,7 +690,7 @@ public:
      * @param eventId is the name of the event
      * @param title is title of the notification to show in the popup.
      * @param text is the text of the notification to show in the popup.
-     * @param pixmap is a picture which may be shown in the popup.
+     * @param image is a picture which may be shown in the popup.
      * @param flags is a bitmask of NotificationFlag
      * @param componentName used to determine the location of the config file.  by default, appname is used
      * @since 4.4
@@ -698,7 +698,7 @@ public:
 	static KNotification* event(const QString& eventId,
 	                            const QString& title,
 	                            const QString& text,
-	                            const QPixmap& pixmap = QPixmap(),
+	                            const QImage& image = QImage(),
 	                            const NotificationFlags& flags = CloseOnTimeout,
 	                            const QString& componentName = QString());
 
@@ -711,13 +711,13 @@ public:
      *
      * @param eventId is the name of the event
      * @param text is the text of the notification to show in the popup.
-     * @param pixmap is a picture which may be shown in the popup.
+     * @param image is a picture which may be shown in the popup.
      * @param flags is a bitmask of NotificationFlag
      * @param componentName used to determine the location of the config file.  by default, plasma_workspace is used
      */
 	static KNotification* event(const QString& eventId,
 	                            const QString& text = QString(),
-	                            const QPixmap& pixmap = QPixmap(),
+	                            const QImage& image = QImage(),
 	                            const NotificationFlags& flags = CloseOnTimeout,
 	                            const QString& componentName = QString());
 
@@ -730,11 +730,11 @@ public:
      *
      * @param eventId is the name of the event
      * @param text is the text of the notification to show in the popup
-     * @param pixmap is a picture which may be shown in the popup
+     * @param image is a picture which may be shown in the popup
      * @param flags is a bitmask of NotificationFlag
      */
 	static KNotification*
-	event(StandardEvent eventId, const QString& text = QString(), const QPixmap& pixmap = QPixmap(), const NotificationFlags& flags = CloseOnTimeout);
+	event(StandardEvent eventId, const QString& text = QString(), const QImage& image = QImage(), const NotificationFlags& flags = CloseOnTimeout);
 
 	/**
      * @brief emit a standard event
@@ -746,12 +746,12 @@ public:
      * @param eventId is the name of the event
      * @param title is title of the notification to show in the popup.
      * @param text is the text of the notification to show in the popup
-     * @param pixmap is a picture which may be shown in the popup
+     * @param image is a picture which may be shown in the popup
      * @param flags is a bitmask of NotificationFlag
      * @since 4.4
      */
 	static KNotification*
-	event(StandardEvent eventId, const QString& title, const QString& text, const QPixmap& pixmap, const NotificationFlags& flags = CloseOnTimeout);
+	event(StandardEvent eventId, const QString& title, const QString& text, const QImage& image, const NotificationFlags& flags = CloseOnTimeout);
 
 	/**
      * @brief emit a standard event with the possibility of setting an icon by icon name

--- a/3rdparty/knotifications/src/knotification.h
+++ b/3rdparty/knotifications/src/knotification.h
@@ -9,10 +9,10 @@
 #ifndef KNOTIFICATION_H
 #define KNOTIFICATION_H
 
+#include <QImage>
 #include <QList>
 #include <QObject>
 #include <QPair>
-#include <QImage>
 #include <QUrl>
 #include <QVariant>
 #include <QWindow>

--- a/3rdparty/knotifications/src/knotification_p.h
+++ b/3rdparty/knotifications/src/knotification_p.h
@@ -33,7 +33,7 @@ struct Q_DECL_HIDDEN KNotification::Private {
 	bool ownsActions = true;
 	QString xdgActivationToken;
 	std::unique_ptr<KNotificationReplyAction> replyAction;
-	QPixmap pixmap;
+	QImage image;
 	NotificationFlags flags = KNotification::CloseOnTimeout;
 	QString componentName;
 	KNotification::Urgency urgency = KNotification::DefaultUrgency;

--- a/3rdparty/knotifications/src/knotificationmanager_p.h
+++ b/3rdparty/knotifications/src/knotificationmanager_p.h
@@ -14,7 +14,6 @@
 #include <memory>
 
 class KNotification;
-class QPixmap;
 class KNotificationPlugin;
 
 /**
@@ -43,7 +42,7 @@ public:
 	void close(int id);
 
 	/**
-     * update one notification text and pixmap and actions
+     * update one notification text and image and actions
      */
 	void update(KNotification* n);
 

--- a/3rdparty/knotifications/src/notifybymacosnotificationcenter.mm
+++ b/3rdparty/knotifications/src/notifybymacosnotificationcenter.mm
@@ -127,7 +127,7 @@ void NotifyByMacOSNotificationCenter::notify(KNotification *notification, const 
         internalNotificationId, @"internalId", nil];
     osxNotification.informativeText = text;
 
-    if (notification->pixmap().isNull()) {
+    if (notification->image().isNull()) {
         QIcon notificationIcon = QIcon::fromTheme(notification->iconName());
         if (!notificationIcon.isNull()) {
             osxNotification.contentImage = [[NSImage alloc]
@@ -135,7 +135,7 @@ void NotifyByMacOSNotificationCenter::notify(KNotification *notification, const 
         }
     } else {
         osxNotification.contentImage = [[NSImage alloc]
-            initWithCGImage: notification->pixmap().toImage().toCGImage() size: NSMakeSize(64, 64)];
+            initWithCGImage: notification->image().toCGImage() size: NSMakeSize(64, 64)];
     }
 
     if (notification->actions().isEmpty()) {

--- a/3rdparty/knotifications/src/notifybymacosnotificationcenter.mm
+++ b/3rdparty/knotifications/src/notifybymacosnotificationcenter.mm
@@ -127,18 +127,20 @@ void NotifyByMacOSNotificationCenter::notify(KNotification *notification, const 
         internalNotificationId, @"internalId", nil];
     osxNotification.informativeText = text;
 
-    if (notification->image().isNull()) {
-        QIcon notificationIcon = QIcon::fromTheme(notification->iconName());
+	if (notification->image().isNull()) {
+		QIcon notificationIcon = QIcon::fromTheme(notification->iconName());
         if (!notificationIcon.isNull()) {
             osxNotification.contentImage = [[NSImage alloc]
                 initWithCGImage: notificationIcon.pixmap(QSize(64, 64)).toImage().toCGImage() size: NSMakeSize(64, 64)];
         }
-    } else {
-        osxNotification.contentImage = [[NSImage alloc]
-            initWithCGImage: notification->image().toCGImage() size: NSMakeSize(64, 64)];
-    }
+	}
+	else {
+		osxNotification.contentImage = [[NSImage alloc]
+				initWithCGImage:notification->image().toCGImage()
+						   size:NSMakeSize(64, 64)];
+	}
 
-    if (notification->actions().isEmpty()) {
+	if (notification->actions().isEmpty()) {
         // Remove all buttons
         osxNotification.hasReplyButton = false;
         osxNotification.hasActionButton = false;

--- a/3rdparty/knotifications/src/notifybypopup.cpp
+++ b/3rdparty/knotifications/src/notifybypopup.cpp
@@ -305,13 +305,8 @@ bool NotifyByPopup::sendNotificationToServer(KNotification* notification, const 
 
 	// FIXME - re-enable/fix
 	// let's see if we've got an image, and store the image in the hints map
-	if (!notification->pixmap().isNull()) {
-		QByteArray pixmapData;
-		QBuffer buffer(&pixmapData);
-		buffer.open(QIODevice::WriteOnly);
-		notification->pixmap().save(&buffer, "PNG");
-		buffer.close();
-		hintsMap[QStringLiteral("image_data")] = ImageConverter::variantForImage(QImage::fromData(pixmapData));
+	if (!notification->image().isNull()) {
+		hintsMap[QStringLiteral("image-data")] = ImageConverter::variantForImage(notification->image());
 	}
 
 	// Persistent     => 0  == infinite timeout

--- a/3rdparty/knotifications/src/notifybyportal.cpp
+++ b/3rdparty/knotifications/src/notifybyportal.cpp
@@ -296,16 +296,16 @@ bool NotifyByPortalPrivate::sendNotificationToPortal(KNotification* notification
 	qDBusRegisterMetaType<QList<QVariantMap>>();
 	qDBusRegisterMetaType<PortalIcon>();
 
-	if (!notification->pixmap().isNull()) {
-		QByteArray pixmapData;
-		QBuffer buffer(&pixmapData);
+	if (!notification->image().isNull()) {
+		QByteArray imageData;
+		QBuffer buffer(&imageData);
 		buffer.open(QIODevice::WriteOnly);
-		notification->pixmap().save(&buffer, "PNG");
+		notification->image().save(&buffer, "PNG");
 		buffer.close();
 
 		PortalIcon icon;
 		icon.str = QStringLiteral("bytes");
-		icon.data.setVariant(pixmapData);
+		icon.data.setVariant(imageData);
 		portalArgs.insert(QStringLiteral("icon"), QVariant::fromValue<PortalIcon>(icon));
 	}
 	else {

--- a/3rdparty/knotifications/src/notifybysnore.cpp
+++ b/3rdparty/knotifications/src/notifybysnore.cpp
@@ -174,8 +174,8 @@ void NotifyBySnore::notifyDeferred(KNotification* notification)
 
 	// handle the icon for toast notification
 	const QString iconPath = m_iconDir.path() + QLatin1Char('/') + QString::number(notification->id());
-	const bool hasIcon = (notification->pixmap().isNull()) ? qApp->windowIcon().pixmap(1024, 1024).save(iconPath, "PNG")//
-														   : notification->pixmap().save(iconPath, "PNG");
+	const bool hasIcon = (notification->image().isNull()) ? qApp->windowIcon().pixmap(1024, 1024).save(iconPath, "PNG")//
+														   : notification->image().save(iconPath, "PNG");
 	if (hasIcon) {
 		snoretoastArgsList << QStringLiteral("-p") << iconPath;
 	}

--- a/3rdparty/knotifications/src/notifybysnore.cpp
+++ b/3rdparty/knotifications/src/notifybysnore.cpp
@@ -175,7 +175,7 @@ void NotifyBySnore::notifyDeferred(KNotification* notification)
 	// handle the icon for toast notification
 	const QString iconPath = m_iconDir.path() + QLatin1Char('/') + QString::number(notification->id());
 	const bool hasIcon = (notification->image().isNull()) ? qApp->windowIcon().pixmap(1024, 1024).save(iconPath, "PNG")//
-														   : notification->image().save(iconPath, "PNG");
+														  : notification->image().save(iconPath, "PNG");
 	if (hasIcon) {
 		snoretoastArgsList << QStringLiteral("-p") << iconPath;
 	}

--- a/gui/trayitem.cpp
+++ b/gui/trayitem.cpp
@@ -201,10 +201,11 @@ void TrayItem::songChanged(const Song& song, bool isPlaying)
 		if (useable && isPlaying) {
 			if (songNotif == nullptr) {
 				songNotif = new KNotification("newSong");
+				songNotif->setAutoDelete(false);
 			}
 			songNotif->setTitle(song.mainText());
 			songNotif->setText(song.subText());
-			songNotif->setPixmap(QPixmap::fromImage(CurrentCover::self()->image()));
+			songNotif->setImage(CurrentCover::self()->image().scaledToHeight(512));
 			songNotif->setUrgency(KNotification::LowUrgency);
 			songNotif->sendEvent();
 		}

--- a/gui/trayitem.cpp
+++ b/gui/trayitem.cpp
@@ -205,7 +205,7 @@ void TrayItem::songChanged(const Song& song, bool isPlaying)
 			}
 			songNotif->setTitle(song.mainText());
 			songNotif->setText(song.subText());
-			songNotif->setImage(CurrentCover::self()->image().scaledToHeight(512));
+			songNotif->setImage(CurrentCover::self()->image().scaledToHeight(512, Qt::SmoothTransformation));
 			songNotif->setUrgency(KNotification::LowUrgency);
 			songNotif->sendEvent();
 		}


### PR DESCRIPTION
Refactor KNotification to use QImage instead of tossing around QPixmaps. This reduces unnessecary serialization. In addition, resize notification thumbnail to 512px.

The GUI might still take too long to update for extremely large images, as resizing is not free. This is still an improvement.

In the future, we could cache these smaller thumbnails, or on Linux, pass the `image-path` parameter.

Also, disable `autoDelete` on the notification to prevent use-after-free crashes.

Addresses #22, #17.