### PR TITLE
fix: #15 update QMediaPlayer handling

### DIFF
--- a/mpd-interface/httpstream.h
+++ b/mpd-interface/httpstream.h
@@ -62,7 +62,7 @@ private Q_SLOTS:
 	void streamUrl(const QString& url);
 	void checkPlayer();
 #ifndef LIBVLC_FOUND
-	void bufferingProgress(int progress);
+	void mediaStatus(QMediaPlayer::MediaStatus status);
 #endif
 
 private:


### PR DESCRIPTION
Use mediaStatusChanged instead of bufferProgressChanged to tell the player to start.

Fixes #15 