### PR TITLE
fix: libvlc build

### DIFF
--- a/mpd-interface/httpstream.cpp
+++ b/mpd-interface/httpstream.cpp
@@ -218,7 +218,9 @@ void HttpStream::updateStatus()
 #endif
 
 	if (status->state() == state && !playerNeedsToStart) {
+#ifndef LIBVLC_FOUND
 		player->play();
+#endif
 		return;
 	}
 


### PR DESCRIPTION
Building 3.5.1 with libvlc fails:
```
[ 50%] Building CXX object CMakeFiles/cantata.dir/gui/initialsettingswizard.cpp.o
/build/source/mpd-interface/httpstream.cpp: In member function 'void HttpStream::updateStatus()':
/build/source/mpd-interface/httpstream.cpp:221:23: error: invalid use of incomplete type 'libvlc_media_player_t' {aka 'struct libvlc_media_player_t'}
  221 |                 player->play();
      |                       ^~
In file included from /nix/store/jiwfxra0v96dgzaxz51msp4j9x6varfn-libvlc-3.0.21/include/vlc/vlc.h:43,
                 from /build/source/mpd-interface/httpstream.h:30,
                 from /build/source/mpd-interface/httpstream.cpp:24:
/nix/store/jiwfxra0v96dgzaxz51msp4j9x6varfn-libvlc-3.0.21/include/vlc/libvlc_media_player.h:43:16: note: forward declaration of 'libvlc_media_player_t' {aka 'struct libvlc_media_player_t'}
   43 | typedef struct libvlc_media_player_t libvlc_media_player_t;
      |                ^~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/cantata.dir/build.make:246: CMakeFiles/cantata.dir/mpd-interface/httpstream.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:339: CMakeFiles/cantata.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
error: builder for '/nix/store/krkzkc07ckpy6z7jj1g7b55w6iq8ahzd-cantata-3.2.1.drv' failed with exit code 2;
       last 10 log lines:
       > In file included from /nix/store/jiwfxra0v96dgzaxz51msp4j9x6varfn-libvlc-3.0.21/include/vlc/vlc.h:43,
       >                  from /build/source/mpd-interface/httpstream.h:30,
       >                  from /build/source/mpd-interface/httpstream.cpp:24:
       > /nix/store/jiwfxra0v96dgzaxz51msp4j9x6varfn-libvlc-3.0.21/include/vlc/libvlc_media_player.h:43:16: note: forward declaration of 'libvlc_media_player_t' {aka 'struct libvlc_media_player_t'}
       >    43 | typedef struct libvlc_media_player_t libvlc_media_player_t;
       >       |                ^~~~~~~~~~~~~~~~~~~~~
       > make[2]: *** [CMakeFiles/cantata.dir/build.make:246: CMakeFiles/cantata.dir/mpd-interface/httpstream.cpp.o] Error 1
       > make[2]: *** Waiting for unfinished jobs....
       > make[1]: *** [CMakeFiles/Makefile2:339: CMakeFiles/cantata.dir/all] Error 2
       > make: *** [Makefile:156: all] Error 2
       For full logs, run 'nix-store -l /nix/store/krkzkc07ckpy6z7jj1g7b55w6iq8ahzd-cantata-3.2.1.drv'.
```

The offending line was added in 3.5.1 to fix [#15](https://github.com/nullobsi/cantata/issues/15) (the http streaming for QMediaPlayer...): https://github.com/nullobsi/cantata/pull/26/files#diff-8baa1220f424fb4bd613a155d20e58839ec85bf8098ae9a3795ce698c4a1a341R221

So, it just needed a trivial `#ifndef LIBVLC_FOUND`.

Thanks.