### PR TITLE
fix: remove .desktop from MPRIS DesktopEntry

### DIFF
--- a/dbus/mpris.h
+++ b/dbus/mpris.h
@@ -105,7 +105,7 @@ public:
 	bool CanRaise() const { return true; }
 	bool HasTrackList() const { return false; }
 	QString Identity() const { return QLatin1String(PACKAGE_NAME); }
-	QString DesktopEntry() const { return QLatin1String(PROJECT_REV_ID ".desktop"); }
+	QString DesktopEntry() const { return QLatin1String(PROJECT_REV_ID); }
 	QStringList SupportedUriSchemes() const { return QStringList(); }
 	QStringList SupportedMimeTypes() const { return QStringList(); }
 


### PR DESCRIPTION
By [the spec](https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:DesktopEntry), `org.mpris.MediaPlayer2:DesktopEntry` should not contain the .desktop suffix. This fixes lookups of the desktop entry by MPRIS clients.