### PR TITLE
fix: #39 Change default podcast save directory

### DIFF
--- a/gui/settings.cpp
+++ b/gui/settings.cpp
@@ -634,7 +634,7 @@ QDateTime Settings::lastRssUpdate()
 
 QString Settings::podcastDownloadPath()
 {
-	return Utils::fixPath(cfg.get("podcastDownloadPath", Utils::fixPath(QDir::homePath()) + QLatin1String("Podcasts/")));
+	return Utils::fixPath(cfg.get("podcastDownloadPath", Utils::fixPath(QDir::homePath()) + QLatin1String("Music/Podcasts/")));
 }
 
 int Settings::podcastAutoDownloadLimit()


### PR DESCRIPTION
Flatpak does not have access to home directory. It must save under ~/Music, which it does have access to.

Fixes #39 