### PR TITLE
fix: #37 timestamp on podcasts

### DIFF
--- a/gui/settings.cpp
+++ b/gui/settings.cpp
@@ -634,7 +634,7 @@ QDateTime Settings::lastRssUpdate()
 
 QString Settings::podcastDownloadPath()
 {
-	return Utils::fixPath(cfg.get("podcastDownloadPath", Utils::fixPath(QDir::homePath()) + QLatin1String("Podcasts/")));
+	return Utils::fixPath(cfg.get("podcastDownloadPath", Utils::fixPath(QDir::homePath()) + QLatin1String("Music/Podcasts/")));
 }
 
 int Settings::podcastAutoDownloadLimit()

--- a/online/rssparser.cpp
+++ b/online/rssparser.cpp
@@ -72,7 +72,7 @@ static QDateTime parseRfc822DateTime(const QString& text)
 
 	static const QRegularExpression re(R"(([a-zA-Z]{3}),? (\d{1,2}) ([a-zA-Z]{3}) (\d{4}) (\d{1,2}):(\d{1,2}):(\d{1,2}))");
 	auto match = re.match(text);
-	if (match.hasMatch()) {
+	if (!match.hasMatch()) {
 		return QDateTime();
 	}
 


### PR DESCRIPTION
Typo introduced in f85d76e9a2a2409b2737d59e0685ea8d1ea4fed3.

Fixes #37.