### PR TITLE
build: Link to libmusicbrainzcc, not libmusicbrainz

### DIFF
--- a/cmake/FindMusicBrainz5.cmake
+++ b/cmake/FindMusicBrainz5.cmake
@@ -40,7 +40,7 @@ The following cache variables may also be set:
 # First use PKG-Config as a starting point.
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
-    pkg_check_modules(PC_MusicBrainz5 QUIET libmusicbrainz5)
+    pkg_check_modules(PC_MusicBrainz5 QUIET libmusicbrainz5cc)
 endif(PKG_CONFIG_FOUND)
 
 find_path(MusicBrainz5_INCLUDE_DIR
@@ -50,7 +50,7 @@ find_path(MusicBrainz5_INCLUDE_DIR
 )
 
 find_library(MusicBrainz5_LIBRARY
-    NAMES musicbrainz5
+    NAMES musicbrainz5cc
     PATHS ${PC_MusicBrainz5_LIBRARY_DIRS}
 )
 


### PR DESCRIPTION
Fix linking when the ENABLE_MUSICBRAINZ option is true. This was regressed in 8e7f8ef, by linking to the libmusicbrainz (C) library instead of the libmusicbrainzcc (C++) library causing undefined symbols.