### PR TITLE
fix FindCDParanoia.cmake

### DIFF
--- a/cmake/FindCDParanoia.cmake
+++ b/cmake/FindCDParanoia.cmake
@@ -43,6 +43,8 @@ The following cache variables may also be set:
   The directory containing ``cdda_interface.h``.
 #]===]
 
+include(CheckCSourceCompiles)
+
 # First use PKG-Config as a starting point.
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
@@ -96,6 +98,7 @@ if(CDParanoia_FOUND)
     )
   endif ()
   if(NOT TARGET CDDA::Interface)
+    add_library(CDDA::Interface UNKNOWN IMPORTED)
     set_target_properties(CDDA::Interface PROPERTIES
             IMPORTED_LOCATION "${CDParanoia_INTERFACE_LIBRARY}"
             INTERFACE_COMPILE_OPTIONS "${PC_CDParanoia_CFLAGS_OTHER}"


### PR DESCRIPTION
Otherwise : 

> CMake Error at cmake/FindCDParanoia.cmake:99 
> (set_target_properties):
>  set_target_properties Can not find target to add properties to:
>  CDDA::Interface
> Call Stack (most recent call first):
>  CMakeLists.txt:251 (find_package)

> CMake Error at cmake/FindCDParanoia.cmake:104 
> (target_link_libraries):
>  Cannot specify link libraries for target "CDDA::Interface" which is > not
>  built by this project.
> Call Stack (most recent call first):
>  CMakeLists.txt:251 (find_package)