### PR TITLE
Add missing QRegularExpression include

### DIFF
--- a/models/streamsmodel.cpp
+++ b/models/streamsmodel.cpp
@@ -44,6 +44,7 @@
 #include <QLocale>
 #include <QMimeData>
 #include <QModelIndex>
+#include <QRegularExpression>
 #include <QSet>
 #include <QString>
 #include <QTimer>


### PR DESCRIPTION
This fixes the build with Qt 6.9.0-beta2, which otherwise errors out with
"streamsmodel.cpp:1257:58: error: variable 'constQRegularExpression brokenXML' has initializer but incomplete type".