### PR TITLE
fix ODR violations : move enum to headers

### DIFF
--- a/devices/actiondialog.cpp
+++ b/devices/actiondialog.cpp
@@ -65,15 +65,6 @@ int ActionDialog::instanceCount()
 	return iCount;
 }
 
-enum Pages {
-	PAGE_SIZE_CALC,
-	PAGE_INSUFFICIENT_SIZE,
-	PAGE_START,
-	PAGE_ERROR,
-	PAGE_SKIP,
-	PAGE_PROGRESS
-};
-
 ActionDialog::ActionDialog(QWidget* parent)
 	: Dialog(parent), spaceRequired(0), mpdConfigured(false), currentDev(nullptr), songDialog(nullptr)
 {

--- a/devices/actiondialog.h
+++ b/devices/actiondialog.h
@@ -47,6 +47,15 @@ class ActionDialog : public Dialog, Ui::ActionDialog {
 		Sync
 	};
 
+	enum Pages {
+		PAGE_SIZE_CALC,
+		PAGE_INSUFFICIENT_SIZE,
+		PAGE_START,
+		PAGE_ERROR,
+		PAGE_SKIP,
+		PAGE_PROGRESS
+	};
+
 	typedef QPair<QString, QString> StringPair;
 	typedef QList<StringPair> StringPairList;
 

--- a/gui/initialsettingswizard.cpp
+++ b/gui/initialsettingswizard.cpp
@@ -41,13 +41,6 @@
 #include <QTimer>
 #include <filesystem>
 
-enum Pages {
-	PAGE_INTRO,
-	PAGE_CONNECTION,
-	PAGE_COVERS,
-	PAGE_END
-};
-
 InitialSettingsWizard::InitialSettingsWizard(QWidget* p)
 	: QWizard(p)
 {

--- a/gui/initialsettingswizard.h
+++ b/gui/initialsettingswizard.h
@@ -32,6 +32,13 @@
 class InitialSettingsWizard : public QWizard, public Ui::InitialSettingsWizard {
 	Q_OBJECT
 
+	enum Pages {
+		PAGE_INTRO,
+		PAGE_CONNECTION,
+		PAGE_COVERS,
+		PAGE_END
+	};
+
 public:
 	InitialSettingsWizard(QWidget* p = nullptr);
 	~InitialSettingsWizard() override;

--- a/online/podcastsearchdialog.cpp
+++ b/online/podcastsearchdialog.cpp
@@ -64,14 +64,6 @@ static QCache<QUrl, QImage> imageCache(200 * 1024);
 static int maxImageSize = -1;
 static const char* constOrigUrlProperty = "orig-url";
 
-enum Roles {
-	IsPodcastRole = Qt::UserRole,
-	UrlRole,
-	ImageUrlRole,
-	DescriptionRole,
-	WebPageUrlRole
-};
-
 QString PodcastSearchDialog::constCacheDir = QLatin1String("podcast-directories");
 QString PodcastSearchDialog::constExt = QLatin1String(".opml");
 

--- a/online/podcastsearchdialog.h
+++ b/online/podcastsearchdialog.h
@@ -47,6 +47,15 @@ struct Podcast;
 
 class PodcastPage : public QWidget {
 	Q_OBJECT
+
+	enum Roles {
+		IsPodcastRole = Qt::UserRole,
+		UrlRole,
+		ImageUrlRole,
+		DescriptionRole,
+		WebPageUrlRole
+	};
+
 public:
 	PodcastPage(QWidget* p, const QString& n);
 	~PodcastPage() override


### PR DESCRIPTION
fix multiple ODR violations : move enums into class scope in headers

online/podcastsearchdialog.cpp:67:6: error: type ‘Roles’ violates the C++ One Definition Rule
devices/albumdetailsdialog.cpp:311:6: note: an enum with different value name is defined in another translation unit
gui/initialsettingswizard.cpp:44:6: error: type ‘Pages’ violates the C++ One Definition Rule
devices/actiondialog.cpp:68:6: note: an enum with different value name is defined in another translation unit

