### PR TITLE
cantata-dynamic: use new cache location

### DIFF
--- a/playlists/cantata-dynamic.cmake
+++ b/playlists/cantata-dynamic.cmake
@@ -210,7 +210,7 @@ sub baseDir() {
     if (!$cacheDir) {
         $cacheDir="$ENV{'HOME'}/.cache";
     }
-    $cacheDir="${cacheDir}/cantata/dynamic";
+    $cacheDir="${cacheDir}/Cantata/dynamic";
     return $cacheDir
 }
 
@@ -358,7 +358,7 @@ sub saveRule() {
     }
 }
 
-# Read rules from ~/.cache/cantata/dynamic/rules
+# Read rules from ~/.cache/Cantata/dynamic/rules
 #  (or from ${filesDir}/rules in server mode)
 #
 # File format:


### PR DESCRIPTION
In Cantata 2 the cache location was `${XDG_CACHE_HOME}/cantata` with a lower case `c`. Cantata 3 uses `${XDG_CACHE_HOME}/Cantata` with an upper case `C` due to the migration of configuration and data paths. The `cantata-dynamic` perl script was not updated to reflect this change, which causes dynamic playlists to stop working.

On systems that migrated from v2 to v3 the `cantata-dynamic` script will just forever use the last used playlist of v2. Not even stopping the playlist is possible once started because it depends on the current state which will never be updated. On systems that didn't have v2 installed prior the behavior is unknown I would assume. At worst, dynamic playlists just don't work at all.

This PR updates the cache location in the perl script.

There is a code path for macOS in the script which points to `${HOME}/Library/Caches/cantata/cantata/dynamic`. I don't have access to a macOS machine, but from guessing how Qt works this path probably needs to be updated too. A macOS user needs to confirm the correct cache location please.