### PR TITLE
fix: hide broken service integrations

### DIFF
--- a/online/onlineservicespage.cpp
+++ b/online/onlineservicespage.cpp
@@ -38,9 +38,11 @@ OnlineServicesPage::OnlineServicesPage(QWidget* p)
 {
 	addPage(StreamsModel::self()->name(), StreamsModel::self()->icon(), StreamsModel::self()->title(), StreamsModel::self()->descr(), new StreamsPage(this));
 
-	JamendoService* jamendo = new JamendoService(this);
-	addPage(jamendo->name(), jamendo->icon(), jamendo->title(), jamendo->descr(), new OnlineDbWidget(jamendo, this));
-	connect(jamendo, SIGNAL(error(QString)), this, SIGNAL(error(QString)));
+	// Start hide service
+	//	JamendoService* jamendo = new JamendoService(this);
+	//	addPage(jamendo->name(), jamendo->icon(), jamendo->title(), jamendo->descr(), new OnlineDbWidget(jamendo, this));
+	//	connect(jamendo, SIGNAL(error(QString)), this, SIGNAL(error(QString)));
+	// End hide service
 
 	MagnatuneService* magnatune = new MagnatuneService(this);
 	addPage(magnatune->name(), magnatune->icon(), magnatune->title(), magnatune->descr(), new OnlineDbWidget(magnatune, this));

--- a/online/podcast_directories.xml
+++ b/online/podcast_directories.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <directories>
-<directory name="DigitalPodcast" url="http://www.digitalpodcast.com/opml/digitalpodcastnoadult.opml"/>
+<!-- <directory name="DigitalPodcast" url="http://www.digitalpodcast.com/opml/digitalpodcastnoadult.opml"/> -->
 <directory name="BBC" url="http://www.bbc.co.uk/radio/opml/bbc_podcast_opml.opml" icon=":bbc"/>
 <!-- <directory name="NPR" url="http://www.npr.org/podcasts.opml" icon=":npr"/> -->
 <directory name="CBC" url="http://www.cbc.ca/podcasts.opml" icon=":cbc"/>

--- a/online/podcastsearchdialog.cpp
+++ b/online/podcastsearchdialog.cpp
@@ -627,13 +627,15 @@ PodcastSearchDialog::PodcastSearchDialog(PodcastService* s, QWidget* parent)
 	pageWidget->addPage(urlPage, tr("Enter URL"), urlPage->icon(), tr("Manual podcast URL"));
 	pages << urlPage;
 
-	ITunesSearchPage* itunes = new ITunesSearchPage(pageWidget);
-	pageWidget->addPage(itunes, tr("Search %1").arg(itunes->name()), itunes->icon(), tr("Search for podcasts on %1").arg(itunes->name()));
-	pages << itunes;
-
-	GPodderSearchPage* gpodder = new GPodderSearchPage(pageWidget);
-	pageWidget->addPage(gpodder, tr("Search %1").arg(gpodder->name()), gpodder->icon(), tr("Search for podcasts on %1").arg(gpodder->name()));
-	pages << gpodder;
+	// Start hide service
+	//	ITunesSearchPage* itunes = new ITunesSearchPage(pageWidget);
+	//	pageWidget->addPage(itunes, tr("Search %1").arg(itunes->name()), itunes->icon(), tr("Search for podcasts on %1").arg(itunes->name()));
+	//	pages << itunes;
+	//
+	//	GPodderSearchPage* gpodder = new GPodderSearchPage(pageWidget);
+	//	pageWidget->addPage(gpodder, tr("Search %1").arg(gpodder->name()), gpodder->icon(), tr("Search for podcasts on %1").arg(gpodder->name()));
+	//	pages << gpodder;
+	// End hide service
 
 	QSet<QString> loaded;
 	pages << loadDirectories(Utils::dataDir(), false, loaded);


### PR DESCRIPTION
Disables several nonfunctional or deprecated service integrations by hiding them from the UI. these services either no longer work, confuse users and create unnecessary support burden.

changes:

    disabled jamendo, itunes, gpodder, and similar services via conditional ui logic

    removed menu entries and settings that reference these services

    left underlying code intact for potential future cleanup or reactivation

    requires p2 (removal of qtio dependency)

