### PR TITLE
Don't ignore failing to open files completely

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -405,7 +405,9 @@ int main(int argc, char* argv[])
 	// Create the file if it doesn't exist already
 	if (!QFile::exists(s.fileName())) {
 		QFile file(s.fileName());
-		file.open(QIODevice::WriteOnly);
+		if (!file.open(QIODevice::WriteOnly)) {
+			qWarning() << "Failed to open settings file: " << s.fileName();
+		}
 	}
 
 	// Set -rw-------

--- a/mpd-interface/cuefile.cpp
+++ b/mpd-interface/cuefile.cpp
@@ -263,7 +263,9 @@ bool CueFile::parse(const QString& fileName, const QString& dir, QList<Song>& so
 		if (!textStream) {
 			decoded.clear();
 			// Failed to use text decoders, fall back to old method...
-			f.open(QIODevice::ReadOnly | QIODevice::Text);
+			if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+				return false;
+			}
 			textStream.reset(new QTextStream(&f));
 			std::optional<QStringConverter::Encoding> encoding = QStringDecoder::encodingForData(f.peek(1024));
 			textStream->setEncoding(encoding.value_or(QStringConverter::Utf8));


### PR DESCRIPTION
Fixes the build with Qt 6.10, where QFile::open() is now marked with [[nodiscard]].