### PR TITLE
Port away from deprecated QSortFilterProxyModel::invalidateFilter()

### DIFF
--- a/models/proxymodel.cpp
+++ b/models/proxymodel.cpp
@@ -150,7 +150,12 @@ bool ProxyModel::update(const QString& txt)
 			filterEnabled = false;
 			if (!wasEmpty) {
 				//                qWarning() << "INVALIDATE (empty from non)";
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
+				beginFilterChange();
+				endFilterChange();
+#else
 				invalidateFilter();
+#endif
 				//                qWarning() << "DONE";
 			}
 			return true;
@@ -159,7 +164,12 @@ bool ProxyModel::update(const QString& txt)
 	else {
 		filterEnabled = true;
 		//        qWarning() << "INVALIDATE (changed)";
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
+		beginFilterChange();
+		endFilterChange();
+#else
 		invalidateFilter();
+#endif
 		//        qWarning() << "DONE";
 		return true;
 	}

--- a/online/podcastservice.cpp
+++ b/online/podcastservice.cpp
@@ -78,8 +78,14 @@ PodcastService::Proxy::Proxy(QObject* parent)
 void PodcastService::Proxy::showUnplayedOnly(bool on)
 {
 	if (on != unplayedOnly) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 10, 0))
+		beginFilterChange();
+		unplayedOnly = on;
+		endFilterChange();
+#else
 		unplayedOnly = on;
 		invalidateFilter();
+#endif
 	}
 }
 


### PR DESCRIPTION
It has been deprecated with 6.10.