### PR TITLE
Spelling fixes in code (and translations)

### DIFF
--- a/online/onlinedbwidget.cpp
+++ b/online/onlinedbwidget.cpp
@@ -110,7 +110,7 @@ void OnlineDbWidget::showEvent(QShowEvent* e)
 
 void OnlineDbWidget::firstTimePrompt()
 {
-	if (MessageBox::No == MessageBox::questionYesNo(this, srv->averageSize() ? tr("The music listing needs to be downloaded, this can consume over %1Mb of disk space").arg(srv->averageSize()) : tr("Dowload music listing?"), QString(), GuiItem(tr("Download")), StdGuiItem::cancel())) {
+	if (MessageBox::No == MessageBox::questionYesNo(this, srv->averageSize() ? tr("The music listing needs to be downloaded, this can consume over %1Mb of disk space").arg(srv->averageSize()) : tr("Download music listing?"), QString(), GuiItem(tr("Download")), StdGuiItem::cancel())) {
 		emit close();
 	}
 	else {

--- a/playlists/playlistrule.ui
+++ b/playlists/playlistrule.ui
@@ -253,7 +253,7 @@
    <item>
     <widget class="NoteLabel" name="label_7y">
      <property name="text">
-      <string>If 'Exact match' is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. 'AB' would match 'ABBA'.</string>
+      <string>If 'Exact match' is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. 'AB' would match 'ABBA'.</string>
      </property>
     </widget>
    </item>

--- a/translations/blank.ts
+++ b/translations/blank.ts
@@ -3795,7 +3795,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/blank.ts
+++ b/translations/blank.ts
@@ -4403,7 +4403,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_cs.ts
+++ b/translations/cantata_cs.ts
@@ -10838,7 +10838,7 @@ Tento krok nelze vrátit zpět.</translation>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation>Pokud je zaškrtnuta Přesná shoda, budou se v hodnotách řetězců hledat přesné hodnoty. V opačném případě budou zahrnuty i částečné shody, například AB odpovídá ABBA.</translation>
     </message>
     <message>

--- a/translations/cantata_cs.ts
+++ b/translations/cantata_cs.ts
@@ -3124,7 +3124,7 @@ i18n: ectx: property (text), widget (BuddyLabel, label_3)
         <translation type="vanished">Je třeba stáhnout seznamu hudby. To může spotřebovat přes %1 MB místa na disku</translation>
     </message>
     <message>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation type="vanished">Stáhnout seznam hudby</translation>
     </message>
     <message>
@@ -10228,7 +10228,7 @@ Tento krok nelze vrátit zpět.</translation>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>Stáhnout seznam hudby?</translation>
     </message>
     <message>

--- a/translations/cantata_da.ts
+++ b/translations/cantata_da.ts
@@ -3841,7 +3841,7 @@ Det kan ikke fortrydes.</translation>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>Download musiklistning?</translation>
     </message>
     <message>

--- a/translations/cantata_da.ts
+++ b/translations/cantata_da.ts
@@ -4450,7 +4450,7 @@ Det kan ikke fortrydes.</translation>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation>Hvis &apos;Præcist match&apos; er tilvalgt, så vil strengværdier blive matchet for præcise værdier. Ellers inkluderes også delvise match, f.eks. vil &apos;AB&apos; matche &apos;ABBA&apos;.</translation>
     </message>
     <message>

--- a/translations/cantata_de.ts
+++ b/translations/cantata_de.ts
@@ -8419,7 +8419,7 @@ Dies kann nicht rückgängig gemacht werden.</translation>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_de.ts
+++ b/translations/cantata_de.ts
@@ -7810,7 +7810,7 @@ Dies kann nicht rückgängig gemacht werden.</translation>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>Musikliste herunterladen?</translation>
     </message>
     <message>

--- a/translations/cantata_en_GB.ts
+++ b/translations/cantata_en_GB.ts
@@ -4502,7 +4502,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_en_GB.ts
+++ b/translations/cantata_en_GB.ts
@@ -3893,7 +3893,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_es.ts
+++ b/translations/cantata_es.ts
@@ -9383,7 +9383,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_es.ts
+++ b/translations/cantata_es.ts
@@ -8774,7 +8774,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_fi.ts
+++ b/translations/cantata_fi.ts
@@ -3918,7 +3918,7 @@ Tätä ei voi kumota.</translation>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>Ladataanko musiikkiluettelot?</translation>
     </message>
     <message>

--- a/translations/cantata_fi.ts
+++ b/translations/cantata_fi.ts
@@ -4527,7 +4527,7 @@ Tätä ei voi kumota.</translation>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_fr.ts
+++ b/translations/cantata_fr.ts
@@ -9733,7 +9733,7 @@ Cette action est définitive.</translation>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_fr.ts
+++ b/translations/cantata_fr.ts
@@ -9124,7 +9124,7 @@ Cette action est définitive.</translation>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>Télécharger la liste de musique ?</translation>
     </message>
     <message>

--- a/translations/cantata_hu.ts
+++ b/translations/cantata_hu.ts
@@ -9610,7 +9610,7 @@ Ezt nem lehet visszavonni!</translation>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_hu.ts
+++ b/translations/cantata_hu.ts
@@ -10218,7 +10218,7 @@ Ezt nem lehet visszavonni!</translation>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_it.ts
+++ b/translations/cantata_it.ts
@@ -4564,7 +4564,7 @@ Non sarà possibile tornare indietro.</translation>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation>Quando &apos;Corrispondenza esatta&apos; è attivo, i valori delle stringhe verranno confrontati con i valori esatti. In caso contrario, verranno incluse anche le corrispondenze parziali. es. &apos;AB&apos; farebbe risultare &apos;ABBA&apos;.</translation>
     </message>
     <message>

--- a/translations/cantata_it.ts
+++ b/translations/cantata_it.ts
@@ -3955,7 +3955,7 @@ Non sarà possibile tornare indietro.</translation>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>Scaricare la lista musicale?</translation>
     </message>
     <message>

--- a/translations/cantata_ja.ts
+++ b/translations/cantata_ja.ts
@@ -4547,7 +4547,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_ja.ts
+++ b/translations/cantata_ja.ts
@@ -3939,7 +3939,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>音楽リストをダウンロードしますか?</translation>
     </message>
     <message>

--- a/translations/cantata_ko.ts
+++ b/translations/cantata_ko.ts
@@ -3104,7 +3104,7 @@ i18n: ectx: property (text), widget (BuddyLabel, label_3)
         <translation type="vanished">음악 항목을 내려받는 데에 %1Mb 디스크 용량이 필요합니다</translation>
     </message>
     <message>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation type="vanished">음악 항목을 내려받을까요?</translation>
     </message>
     <message>
@@ -10186,7 +10186,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation type="unfinished">음악 항목을 내려받을까요?</translation>
     </message>
     <message>

--- a/translations/cantata_ko.ts
+++ b/translations/cantata_ko.ts
@@ -10794,7 +10794,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished">&apos;정확한 맞춤&apos;을 사용하면, 문자열 값을 정확하게 맞춥니다. 아니면 부분 맞춤이 포함됩니다. 예. &apos;AB&apos;는  &apos;ABBA&apos;를 포함합니다.</translation>
     </message>
     <message>

--- a/translations/cantata_nl.ts
+++ b/translations/cantata_nl.ts
@@ -4560,7 +4560,7 @@ Dit kan niet ongedaan worden gemaakt.</translation>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation>Als &apos;Exacte overeenkomst&apos; is ingeschakeld, worden tekenreekswaarden overeengekomen met exacte waarden. Indien uitgeschakeld, worden ook delen overeengekomen. Voorbeeld: &apos;AB&apos; zou &apos;ABBA&apos; overeen laten komen.</translation>
     </message>
     <message>

--- a/translations/cantata_nl.ts
+++ b/translations/cantata_nl.ts
@@ -3951,7 +3951,7 @@ Dit kan niet ongedaan worden gemaakt.</translation>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>Wil je de muzieklijst downloaden?</translation>
     </message>
     <message>

--- a/translations/cantata_pl.ts
+++ b/translations/cantata_pl.ts
@@ -10860,7 +10860,7 @@ Ta operacja nie może być cofnięta.</translation>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation>Jeżeli opcja &apos;Dokładne dopasowanie&apos; jest zaznaczona, to wartości tekstowe będą dopasowywane w całości. W przeciwnym wypadku częściowe dopasowania również będą uwzględnione, np. do wyszukania &apos;AB&apos; zostanie dopasowane &apos;ABBA&apos;.</translation>
     </message>
     <message>

--- a/translations/cantata_pl.ts
+++ b/translations/cantata_pl.ts
@@ -3141,7 +3141,7 @@ i18n: ectx: property (text), widget (BuddyLabel, label_3)
         <translation type="vanished">Listing muzyki musi zostać pobrany, to może zająć ponad %1Mb miejsca na dysku</translation>
     </message>
     <message>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation type="vanished">Pobrać listing muzyki?</translation>
     </message>
     <message>
@@ -10250,7 +10250,7 @@ Ta operacja nie może być cofnięta.</translation>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>Pobrać listing muzyki?</translation>
     </message>
     <message>

--- a/translations/cantata_pt_BR.ts
+++ b/translations/cantata_pt_BR.ts
@@ -3227,7 +3227,7 @@ Não será possível desfazer esta escolha.</translation>
         <translation>Agrupar por</translation>
     </message>
     <message>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>Baixar a listagem de músicas?</translation>
     </message>
 </context>

--- a/translations/cantata_pt_BR.ts
+++ b/translations/cantata_pt_BR.ts
@@ -3706,7 +3706,7 @@ Não será possível desfazer esta escolha.</translation>
         <translation>Artistas similares a:</translation>
     </message>
     <message>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/cantata_ru.ts
+++ b/translations/cantata_ru.ts
@@ -9650,7 +9650,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_ru.ts
+++ b/translations/cantata_ru.ts
@@ -10260,7 +10260,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_zh_CN.ts
+++ b/translations/cantata_zh_CN.ts
@@ -6275,7 +6275,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../online/onlinedbwidget.cpp" line="117"/>
-        <source>Dowload music listing?</source>
+        <source>Download music listing?</source>
         <translation>下载音乐列表吗？</translation>
     </message>
     <message>

--- a/translations/cantata_zh_CN.ts
+++ b/translations/cantata_zh_CN.ts
@@ -6883,7 +6883,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../playlists/playlistrule.ui" line="256"/>
-        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be inclued. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
+        <source>If &apos;Exact match&apos; is checked, then string values will be matched for exact values. Otherwise partial matches will also be included. e.g. &apos;AB&apos; would match &apos;ABBA&apos;.</source>
         <translation>如果选中“精确匹配”，则将字符串值匹配为精确值。否则，将包括部分匹配。例如“AB”将与“ABBA”匹配。</translation>
     </message>
     <message>


### PR DESCRIPTION
Our Debian packaging linter (`lintian`) also does a limited amount of spell-checking on packages to look for common typos, particularly ones that might be user-visible. 

`lintian` spotted
 - 'inclued' (should be 'included')
 - 'Dowload' (should be 'Download')

This PR fixes the typo in both the code (`cpp` or `ui` file) and the translation (`ts`) files. Since this is a simple typo fix, the localsed `ts` files are fixed in their source strings rather than pestering translators for an updated string.
