### PR TITLE
fix: Grouped Albums Playlist view

### DIFF
--- a/models/playlistsmodel.cpp
+++ b/models/playlistsmodel.cpp
@@ -374,7 +374,7 @@ QVariant PlaylistsModel::data(const QModelIndex& index, int role) const
 		case Cantata::Role_SongWithRating:
 		case Cantata::Role_Song: {
 			QVariant var;
-			var.setValue(*s);
+			var.setValue(static_cast<Song>(*s));
 			return var;
 		}
 		case Cantata::Role_AlbumDuration: {


### PR DESCRIPTION
Correctly store a `Song` in `QVariant` returned from `PlaylistsModel`.
Previously the stored value was of type `PlaylistsModel::SongItem`.
The `GroupedViewDelegate` expects only a `Song`, which is a base class of `PlaylistsModel::SongItem`.

Fixes #68