### PR TITLE
fix: correctly handle absolute INSTALL_LIBEXECDIR

### DIFF
--- a/support/utils.cpp
+++ b/support/utils.cpp
@@ -811,6 +811,10 @@ QString Utils::helper(const QString& app)
 	if (QFile::exists(local)) {
 		return local;
 	}
+	if (QDir::isAbsolutePath(INSTALL_LIBEXECDIR)) {
+		return fixPath(INSTALL_LIBEXECDIR + constDirSep + QCoreApplication::applicationName() + constDirSep) + app;
+	}
+
 	return fixPath(
 				   QCoreApplication::applicationDirPath() + constDirSep + "../" + INSTALL_LIBEXECDIR + constDirSep + QCoreApplication::applicationName() + constDirSep)
 			+ app;


### PR DESCRIPTION
In my Arch Linux with cantata installed via AUR it fails to start cantata-tags.
cantata is installed at `/usr/bin/cantata` and cantata-tags is installed at `/usr/bin/Cantata/cantata-tags`.

Without this change `Utils::helper` first tries `/usr/bin/cantata-tags` and then `/usr/bin/../usr/bin/Cantata/cantata-tags` and returns an incorrect path.