### PR TITLE
feat: Allow sorting playlist by track rating

### DIFF
--- a/models/playqueuemodel.cpp
+++ b/models/playqueuemodel.cpp
@@ -1592,7 +1592,8 @@ void PlayQueueModel::sortBy()
 		}
 		else if (constSortByGrouping == key) {
 			std::stable_sort(copy.begin(), copy.end(), groupingSort);
-		} else if (constSortByRating == key) {
+		}
+		else if (constSortByRating == key) {
 			std::stable_sort(copy.begin(), copy.end(), ratingSort);
 		}
 


### PR DESCRIPTION
Just a minor feature I am missing, I often have playlists that are quite long, and sometimes I just want to listen to the tracks with the highest rating.