### PR TITLE
Fix: Device access from flatpak on Ubuntu and Debian

### DIFF
--- a/dog.unix.cantata.Cantata.yml
+++ b/dog.unix.cantata.Cantata.yml
@@ -13,6 +13,7 @@ finish-args:
   - --filesystem=/run/mpd
   - --filesystem=xdg-run/mpd
   - --filesystem=/run/media
+  - --filesystem=/media
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.UDisks2
 modules:


### PR DESCRIPTION
In Ubuntu and Debian udisks seems to mount devices under `/media`.
This should also fix access from the flatpak-build there.