### PR TITLE
fix/113: enable categorized view

### DIFF
--- a/widgets/singlepagewidget.cpp
+++ b/widgets/singlepagewidget.cpp
@@ -196,8 +196,7 @@ QList<QAction*> SinglePageWidget::createViewActions(QList<ItemView::Mode> modes)
 {
 	QList<QPair<QString, int>> vals;
 	for (ItemView::Mode m : modes) {
-		if (m != ItemView::Mode_Categorized)
-			vals.append(MenuItem(viewTypeString(m), m));
+		vals.append(MenuItem(viewTypeString(m), m));
 	}
 	return createActions(vals, view->viewMode(), this, SLOT(viewModeSelected()));
 }


### PR DESCRIPTION
The previous commit c3a900e4ed903fa0a2820ad2882e8253dfbc8c7b incorrectly undid the compile-time macros to enable/disable categorized view.

However, it appears that the categorized view does still have issues. It can cause complete crashes, and sometimes appears blank/does not update when you change the sort order.