### PR TITLE
Enable bundled FontAwesome by default, regardless of platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,17 +144,16 @@ option(
     OFF
 )
 option(ENABLE_SCROBBLING "Enable scrobbling" ON)
+option(BUNDLED_FONTAWESOME "Use bundled QResources for FontAwesome." ON)
 
 if(WIN32 OR APPLE OR HAIKU)
     option(ENABLE_DEVICES_SUPPORT "Enable suport for external devices" OFF)
 	option(BUNDLED_KCATEGORIZEDVIEW "Compile vendored KCategorizedView" ON)
 	option(BUNDLED_KARCHIVE "Compile vendored KArchive" ON)
-	option(BUNDLED_FONTAWESOME "Use bundled QResources for FontAwesome." ON)
 else()
     option(ENABLE_DEVICES_SUPPORT "Enable suport for external devices" ON)
 	option(BUNDLED_KCATEGORIZEDVIEW "Compile vendored KCategorizedView" OFF)
 	option(BUNDLED_KARCHIVE "Compile vendored KArchive" OFF)
-	option(BUNDLED_FONTAWESOME "Use bundled QResources for FontAwesome." OFF)
     option(
         ENABLE_REMOTE_DEVICES
         "Enable support for remote (sshfs, samba) devices"


### PR DESCRIPTION
This avoids issues with icons when the correct Font Awesome version is not installed.