### PR TITLE
fix: Add workaround for unreadable first run wizard on Windows 11 with dark mode

### DIFF
--- a/gui/initialsettingswizard.cpp
+++ b/gui/initialsettingswizard.cpp
@@ -44,6 +44,11 @@
 InitialSettingsWizard::InitialSettingsWizard(QWidget* p)
 	: QWizard(p)
 {
+#ifdef Q_OS_WIN
+	// Workaround for dark mode issue: https://qt-project.atlassian.net/browse/QTBUG-123853
+	setWizardStyle(WizardStyle::ModernStyle);
+#endif
+
 	setupUi(this);
 	connect(this, SIGNAL(currentIdChanged(int)), SLOT(pageChanged(int)));
 	connect(this, SIGNAL(setDetails(MPDConnectionDetails)), MPDConnection::self(), SLOT(setDetails(MPDConnectionDetails)));


### PR DESCRIPTION
Fixes #117

<img width="1261" height="1108" alt="image" src="https://github.com/user-attachments/assets/aac937f8-7ff7-44c6-b4a4-96b7fe4b2658" />

<img width="1261" height="1108" alt="image" src="https://github.com/user-attachments/assets/ccb8e2c3-c573-46d9-9ac3-bfaae954491b" />
