### PR TITLE
Fix: dynamic playlists with flatpak build

### DIFF
--- a/dog.unix.cantata.Cantata.yml
+++ b/dog.unix.cantata.Cantata.yml
@@ -16,6 +16,7 @@ finish-args:
   - --filesystem=/media
   - --talk-name=org.kde.StatusNotifierWatcher
   - --system-talk-name=org.freedesktop.UDisks2
+  - --env=FLATPAK=1
 modules:
   - name: ebur128
     buildsystem: cmake-ninja

--- a/dog.unix.cantata.Cantata.yml
+++ b/dog.unix.cantata.Cantata.yml
@@ -27,6 +27,49 @@ modules:
         url: https://github.com/jiixyj/libebur128.git
         tag: v1.2.6
         commit: 67b33abe1558160ed76ada1322329b0e9e058b02
+#   Based on https://github.com/flathub/io.github.Hexchat.Plugin.Perl/
+  - name: perl
+    no-autogen: true
+    config-opts: ["-des", "-Duseshrplib", "-Dusethreads"]
+    build-options:
+      cflags: "-fPIC"
+      ldflags: "-fpic"
+    cleanup:
+      - "/man"
+      - "/lib/perl5/site_perl"
+      - "*.pod"
+      - "*.h"
+    sources:
+      - type: archive
+        url: "https://www.cpan.org/src/5.0/perl-5.38.2.tar.gz"
+        sha256: a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e
+        x-data-checker:
+          type: anitya
+          project-id: 13599
+          url-template: "https://www.cpan.org/src/5.0/perl-$version.tar.gz"
+      - type: script
+        dest-filename: configure
+        commands:
+          - "exec ./configure.gnu $@"
+    post-install:
+      - 'chmod -R u+w /app/lib/perl5'
+      - dest: perl-libs/MIME-Base32
+    # https://github.com/flatpak/flatpak-builder-tools/tree/master/cpan with URI::Escape
+  - name: perl-libs
+    buildsystem: simple
+    build-commands:
+      - 'perl-libs/install.sh'
+    # Same as with the Perl module, we need to restore write permission.
+    # However, -f is now passed to avoid errors from trying to touch files from the
+    # above module that are now marked as read-only.
+    post-install:
+      - 'chmod -Rf u+w /app/lib/perl5/site_perl'
+    sources:
+      - perl-libs.json
+    # This step should be customized based on the CPAN packages you're using.
+    cleanup:
+      - '/bin'
+      - '/man'
   - name: cantata
     buildsystem: cmake-ninja
     config-opts:

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1011,6 +1011,9 @@ MainWindow::~MainWindow()
 	}
 	Settings::self()->save();
 	disconnect(MPDConnection::self(), nullptr, nullptr, nullptr);
+	if (Utils::isFlatpak()) {
+		DynamicPlaylists::self()->stop();
+	}
 	if (Settings::self()->stopOnExit()) {
 		DynamicPlaylists::self()->stop();
 		emit terminating();

--- a/perl-libs.json
+++ b/perl-libs.json
@@ -1,0 +1,36 @@
+[
+   {
+      "dest": "perl-libs/MIME-Base32",
+      "sha256": "ab21fa99130e33a0aff6cdb596f647e5e565d207d634ba2ef06bdbef50424e99",
+      "type": "archive",
+      "url": "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/MIME-Base32-1.303.tar.gz"
+   },
+   {
+      "dest": "perl-libs/URI",
+      "sha256": "de64c779a212ff1821896c5ca2bb69e74767d2674cee411e777deea7a22604a8",
+      "type": "archive",
+      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-5.34.tar.gz"
+   },
+   {
+      "commands": [
+         "set -e",
+         "function make_install {",
+         "    mod_dir=$1",
+         "    cd $mod_dir",
+         "    if [ -f 'Makefile.PL' ]; then",
+         "        perl Makefile.PL PREFIX=${FLATPAK_DEST} && make install PREFIX=${FLATPAK_DEST}",
+         "    elif [ -f 'Build.PL' ]; then",
+         "        perl Build.PL && ./Build && ./Build install",
+         "    else",
+         "        echo 'No Makefile.PL or Build.PL found. Do not know how to install this module'",
+         "        exit 1",
+         "    fi",
+         "}",
+         "(make_install perl-libs/MIME-Base32)",
+         "(make_install perl-libs/URI)"
+      ],
+      "dest": "perl-libs",
+      "dest-filename": "install.sh",
+      "type": "script"
+   }
+]

--- a/perl-libs.json
+++ b/perl-libs.json
@@ -1,36 +1,36 @@
 [
-   {
-      "dest": "perl-libs/MIME-Base32",
-      "sha256": "ab21fa99130e33a0aff6cdb596f647e5e565d207d634ba2ef06bdbef50424e99",
-      "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/MIME-Base32-1.303.tar.gz"
-   },
-   {
-      "dest": "perl-libs/URI",
-      "sha256": "de64c779a212ff1821896c5ca2bb69e74767d2674cee411e777deea7a22604a8",
-      "type": "archive",
-      "url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-5.34.tar.gz"
-   },
-   {
-      "commands": [
-         "set -e",
-         "function make_install {",
-         "    mod_dir=$1",
-         "    cd $mod_dir",
-         "    if [ -f 'Makefile.PL' ]; then",
-         "        perl Makefile.PL PREFIX=${FLATPAK_DEST} && make install PREFIX=${FLATPAK_DEST}",
-         "    elif [ -f 'Build.PL' ]; then",
-         "        perl Build.PL && ./Build && ./Build install",
-         "    else",
-         "        echo 'No Makefile.PL or Build.PL found. Do not know how to install this module'",
-         "        exit 1",
-         "    fi",
-         "}",
-         "(make_install perl-libs/MIME-Base32)",
-         "(make_install perl-libs/URI)"
-      ],
-      "dest": "perl-libs",
-      "dest-filename": "install.sh",
-      "type": "script"
-   }
+	{
+		"dest": "perl-libs/MIME-Base32",
+		"sha256": "ab21fa99130e33a0aff6cdb596f647e5e565d207d634ba2ef06bdbef50424e99",
+		"type": "archive",
+		"url": "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/MIME-Base32-1.303.tar.gz"
+	},
+	{
+		"dest": "perl-libs/URI",
+		"sha256": "de64c779a212ff1821896c5ca2bb69e74767d2674cee411e777deea7a22604a8",
+		"type": "archive",
+		"url": "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-5.34.tar.gz"
+	},
+	{
+		"commands": [
+			"set -e",
+			"function make_install {",
+			"    mod_dir=$1",
+			"    cd $mod_dir",
+			"    if [ -f 'Makefile.PL' ]; then",
+			"        perl Makefile.PL PREFIX=${FLATPAK_DEST} && make install PREFIX=${FLATPAK_DEST}",
+			"    elif [ -f 'Build.PL' ]; then",
+			"        perl Build.PL && ./Build && ./Build install",
+			"    else",
+			"        echo 'No Makefile.PL or Build.PL found. Do not know how to install this module'",
+			"        exit 1",
+			"    fi",
+			"}",
+			"(make_install perl-libs/MIME-Base32)",
+			"(make_install perl-libs/URI)"
+		],
+		"dest": "perl-libs",
+		"dest-filename": "install.sh",
+		"type": "script"
+	}
 ]

--- a/playlists/cantata-dynamic.cmake
+++ b/playlists/cantata-dynamic.cmake
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 #  Cantata-Dynamic
 #

--- a/support/utils.cpp
+++ b/support/utils.cpp
@@ -1097,3 +1097,9 @@ int Utils::compare(const QString& a, const QString& b)
 	}
 	return collator->compare(a, b);
 }
+
+bool Utils::isFlatpak()
+{
+	const QByteArray flatpakVar = qgetenv("FLATPAK");
+	return !flatpakVar.isEmpty() && flatpakVar.trimmed() != "0";
+}

--- a/support/utils.h
+++ b/support/utils.h
@@ -133,6 +133,7 @@ extern QPainterPath buildPath(const QRectF& r, double radius);
 extern QColor clampColor(const QColor& col);
 extern QColor monoIconColor();
 extern int compare(const QString& a, const QString& b);
+extern bool isFlatpak();
 }// namespace Utils
 
 #endif


### PR DESCRIPTION
Fixes #91

Starting and stopping dynamic playlists with the flatpak build works.
However, when Cantata is quit while the dynamic playlist is running the cantata-dynamic script keeps running and can only be stopped by killing it externally.