### PR TITLE
Read playlist in chunks to avoid hitting MPDs max_output_buffer

### DIFF
--- a/mpd-interface/mpdconnection.h
+++ b/mpd-interface/mpdconnection.h
@@ -44,6 +44,7 @@
 #include <QStringList>
 #include <QTcpSocket>
 #include <time.h>
+#include <utility>
 
 class QTimer;
 class Thread;
@@ -507,6 +508,7 @@ private:
 	void getStickerSupport();
 	void playFirstTrack(bool emitErrors);
 	void determineIfaceIp();
+	std::pair<QList<Song>, bool> readPlaylistInfoChunked();
 
 private:
 	bool isInitialConnect;


### PR DESCRIPTION
The actual issue is, that MPDs `max_output_buffer` setting is exceeded.
Apparently MPD simply drops the connection when that happens.

A workaround could be to increase the `max_output_buffer` setting.
The obvious client-side fix is to load the playlist in chunks, which this change does.

I am not too happy with the overall UX, though.
While the playlist is loaded (which can take multiple seconds) there is no indication that anything is happening, which can be confusing.

Fixes #72