### PR TITLE
Improve tray icon behavior and KDE integration (patch p5)

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2149,6 +2149,14 @@ void MainWindow::updateStatus(MPDStatus* const status)
 	}
 	if (status->state() != lastState && (MPDState_Playing == status->state() || MPDState_Stopped == status->state())) {
 		startContextTimer();
+		// Queue finished (end of playlist or stop-after-current)
+		if (status->state() == MPDState_Stopped && status->nextSongId() == -1 && Settings::self()->showPopups()) {
+			auto* n = new KNotification(QStringLiteral("queueFinished"));
+			n->setTitle(tr("Queue finished"));
+			n->setText(QString());
+			n->setUrgency(KNotification::NormalUrgency);
+			n->sendEvent();
+		}
 	}
 
 	// Update status info

--- a/gui/trayitem.cpp
+++ b/gui/trayitem.cpp
@@ -121,10 +121,20 @@ void TrayItem::setup()
 	//if (!QSystemTrayIcon::isSystemTrayAvailable()) {
 	//    return;
 	//}
-
+	// Create tray backend
+#if defined(USE_KSNI)
+	trayItem = new KStatusNotifierItem(this);
+	trayItem->setCategory(KStatusNotifierItem::ApplicationStatus);
+	trayItem->setStatus(KStatusNotifierItem::Active);
+	trayItemMenu = new QMenu(nullptr);
+	trayItem->setContextMenu(trayItemMenu);
+#else
 	trayItem = new QSystemTrayIcon(this);
 	trayItem->installEventFilter(new VolumeSliderEventHandler(this));
 	trayItemMenu = new QMenu(nullptr);
+	trayItem->setContextMenu(trayItemMenu);
+#endif
+	// Populate common menu
 	trayItemMenu->addAction(StdActions::self()->prevTrackAction);
 	trayItemMenu->addAction(StdActions::self()->playPauseTrackAction);
 	trayItemMenu->addAction(StdActions::self()->stopPlaybackAction);
@@ -162,12 +172,33 @@ void TrayItem::setup()
 		icon.addFile(QLatin1String(ICON_INSTALL_PREFIX "/scalable/apps/" PROJECT_REV_ID ".svg"));
 	}
 #endif
+
 	trayItem->setIcon(icon);
+#if defined(USE_KSNI)
+	trayItem->setToolTip(QIcon::fromTheme(QStringLiteral(PROJECT_REV_ID)), tr("Cantata"), QString());
+	// KStatusNotifierItem does not need show() or QSystemTrayIcon connections
+#else
 	trayItem->setToolTip(tr("Cantata"));
 	trayItem->show();
-	connect(trayItem, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(trayItemClicked(QSystemTrayIcon::ActivationReason)));
+	connect(trayItem, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
+	        this, SLOT(trayItemClicked(QSystemTrayIcon::ActivationReason)));
+#endif
+
 #endif
 }
+
+#if defined(USE_KSNI)
+void TrayItem::setOverlayPaused(bool paused)
+{
+	if (!trayItem) return;
+	if (paused) {
+		trayItem->setOverlayIconByName(QStringLiteral("media-playback-pause"));
+	}
+	else {
+		trayItem->setOverlayIcon(QIcon());// clear overlay
+	}
+}
+#endif
 
 void TrayItem::trayItemClicked(QSystemTrayIcon::ActivationReason reason)
 {
@@ -194,22 +225,34 @@ void TrayItem::trayItemClicked(QSystemTrayIcon::ActivationReason reason)
 
 void TrayItem::songChanged(const Song& song, bool isPlaying)
 {
-	if (Settings::self()->showPopups()) {
-		bool useable = song.isStandardStream()
-				? !song.title.isEmpty() && !song.name().isEmpty()
-				: !song.title.isEmpty() && !song.artist.isEmpty() && !song.album.isEmpty();
-		if (useable && isPlaying) {
-			if (songNotif == nullptr) {
-				songNotif = new KNotification("newSong");
-				songNotif->setAutoDelete(false);
-			}
-			songNotif->setTitle(song.mainText());
-			songNotif->setText(song.subText());
-			songNotif->setImage(CurrentCover::self()->image().scaledToHeight(512, Qt::SmoothTransformation));
-			songNotif->setUrgency(KNotification::LowUrgency);
-			songNotif->sendEvent();
-		}
+	bool useable = song.isStandardStream()
+			? !song.title.isEmpty() && !song.name().isEmpty()
+			: !song.title.isEmpty() && !song.artist.isEmpty() && !song.album.isEmpty();
+	if (useable && isPlaying && (Utils::KDE == Utils::currentDe() || Settings::self()->showPopups())) {
+		// Plasma controls popup visibility; other desktops use Cantata's setting.
+		auto* n = new KNotification(QStringLiteral("newSong"));
+		// Ensure it maps to cantata.notifyrc (safer for per‑app settings/history)
+		n->setComponentName(QStringLiteral("cantata"));
+		n->setTitle(song.mainText());
+		n->setText(song.subText());
+		n->setImage(CurrentCover::self()->image().scaledToHeight(512, Qt::SmoothTransformation));
+		n->setUrgency(KNotification::LowUrgency);
+		n->sendEvent();
 	}
+
+#if defined(USE_KSNI)
+	const QString title = song.isStandardStream()
+			? song.name()
+			: QStringLiteral("%1 — %2").arg(song.artist, song.title);
+	const QString sub = song.isStandardStream() ? song.title : song.album;
+	setToolTip(QStringLiteral("audio-x-generic"), title, sub);
+	setOverlayPaused(!isPlaying);
+#else
+	const QString oneLine = song.isStandardStream()
+			? QStringLiteral("%1 — %2").arg(song.name(), song.title)
+			: QStringLiteral("%1 — %2").arg(song.artist, song.title);
+	setToolTip(QString(), oneLine, QString());
+#endif
 }
 
 #ifndef Q_OS_MAC

--- a/support/QtAwesome.cpp
+++ b/support/QtAwesome.cpp
@@ -28,7 +28,7 @@
 #endif
 
 // Initializing namespaces need to happen outside a namespace
-static void qtawesome_init_resources()
+[[maybe_unused]] static void qtawesome_init_resources()
 {
 #ifdef BUNDLED_FONTAWESOME
 	Q_INIT_RESOURCE(QtAwesomeFree);
@@ -297,7 +297,7 @@ bool QtAwesome::initFontAwesome()
 	if (hasInit) return true;
 	bool success = true;
 
-	#ifdef BUNDLED_FONTAWESOME
+#ifdef BUNDLED_FONTAWESOME
 	// The macro below internally calls "qInitResources_QtAwesome()". this initializes
 	// the resource system. For a .pri project this isn't required, but when building and using a
 	// static library the resource need to initialized first.
@@ -333,11 +333,11 @@ bool QtAwesome::initFontAwesome()
 			fd.setFontFamily(loadedFontFamilies.at(0));
 		}
 	}
-	#else
+#else
 	for (QtAwesomeFontData& fd : _fontDetails) {
-		fd.setFontFamily(fd.fontFilename()); // yes, what a great semantic use of the variable...
+		fd.setFontFamily(fd.fontFilename());// yes, what a great semantic use of the variable...
 	}
-	#endif
+#endif
 
 	// intialize the brands icon map
 	addToNamedCodePoints(fa::fa_brands, faBrandsIconArray, sizeof(faBrandsIconArray) / sizeof(QtAwesomeNamedIcon));
@@ -564,7 +564,8 @@ QFont::Weight QtAwesomeFontData::fontWeight() const
 	return _fontWeight;
 }
 
-const QString& QtAwesomeFontData::fontStyle() const {
+const QString& QtAwesomeFontData::fontStyle() const
+{
 	return _fontStyle;
 }
 
@@ -586,7 +587,8 @@ void QtAwesomeFontData::setFontWeight(QFont::Weight weight)
 	_fontWeight = weight;
 }
 
-void QtAwesomeFontData::setFontStyle(const QString& style) {
+void QtAwesomeFontData::setFontStyle(const QString& style)
+{
 	_fontStyle = style;
 }
 


### PR DESCRIPTION
Improve tray icon behavior and KDE integration

- Use KStatusNotifierItem on KDE/Plasma when available
- Ensure playback notifications are properly recorded in KDE notification history
- Add notification when the playback queue finishes
- Improve tray tooltip contents for current track

No overlay icons are added at this time.
