### PR TITLE
build: Turn COMPILE_WARNING_AS_ERROR into a cache variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ add_executable(cantata)
 
 set_property(TARGET cantata PROPERTY CXX_STANDARD 17)
 set_property(TARGET cantata PROPERTY POSITION_INDEPENDENT_CODE ON)
-set_property(TARGET cantata PROPERTY COMPILE_WARNING_AS_ERROR ON)
+set_property(TARGET cantata PROPERTY COMPILE_WARNING_AS_ERROR ON CACHE BOOL "")
 target_compile_options(
     cantata
     PRIVATE


### PR DESCRIPTION
The current default may break builds on stricter compilers and provides no benefit in the context of distributions.
e.g. https://bugs.gentoo.org/974493 with a unused-result with clang-21

```
cantata-3.4.0/models/streamsmodel.cpp:1303:3: error: ignoring return value of function declared with 'nodiscard' attribute [-Werror,-Wunused-result]
 1303 |                 compressor->open(QIODevice::ReadOnly);
      |                 ^~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~
1 error generated.
```