### PR TITLE
fix: #139 crash when hovering playlist item in folders view

### DIFF
--- a/models/browsemodel.cpp
+++ b/models/browsemodel.cpp
@@ -236,8 +236,11 @@ QVariant BrowseModel::data(const QModelIndex& index, int role) const
 		if (!Settings::self()->infoTooltips()) {
 			return QVariant();
 		}
-		if (item->isFolder() || Song::Playlist == static_cast<TrackItem*>(item)->getSong().type) {
+		if (item->isFolder()) {
 			return static_cast<FolderItem*>(item)->getPath();
+		}
+		else if (Song::Playlist == static_cast<TrackItem*>(item)->getSong().type) {
+			return static_cast<TrackItem*>(item)->getSong().filePath();
 		}
 		return static_cast<TrackItem*>(item)->getSong().toolTip();
 	case Cantata::Role_SubText:


### PR DESCRIPTION
The crash was caused by a cast to the wrong type when looking up path for tooltip.

Fixes #139