### PR TITLE
fix: #146 adding local files to play queue only adds last folder in selection

### DIFF
--- a/models/browsemodel.cpp
+++ b/models/browsemodel.cpp
@@ -236,8 +236,11 @@ QVariant BrowseModel::data(const QModelIndex& index, int role) const
 		if (!Settings::self()->infoTooltips()) {
 			return QVariant();
 		}
-		if (item->isFolder() || Song::Playlist == static_cast<TrackItem*>(item)->getSong().type) {
+		if (item->isFolder()) {
 			return static_cast<FolderItem*>(item)->getPath();
+		}
+		else if (Song::Playlist == static_cast<TrackItem*>(item)->getSong().type) {
+			return static_cast<TrackItem*>(item)->getSong().filePath();
 		}
 		return static_cast<TrackItem*>(item)->getSong().toolTip();
 	case Cantata::Role_SubText:

--- a/models/playqueuemodel.cpp
+++ b/models/playqueuemodel.cpp
@@ -292,7 +292,7 @@ QStringList PlayQueueModel::parseUrls(const QStringList& urls)
 			QDir d(u.path());
 
 			if (d.exists()) {
-				useable = listFiles(d, useServer, useLocal, handlers);
+				useable += listFiles(d, useServer, useLocal, handlers);
 			}
 			else if (checkExtension(u.path(), constM3uPlaylists)) {
 				useable += expandM3uPlaylist(u.path(), useServer, useLocal, handlers);


### PR DESCRIPTION
When handling the selected files and folders for adding, processing of a folder overwrote the file list, instead of adding to it.

Fixes #146