### PR TITLE
Add new extraction methods to lyrics providers and drop some defunct ones

### DIFF
--- a/context/lyrics_providers.xml
+++ b/context/lyrics_providers.xml
@@ -128,10 +128,20 @@
       <urlFormat replace="Çç" with="c"/>
       <urlFormat replace="ß" with="ss"/>
       <urlFormat replace="&amp;" with="and"/>
+    <!-- Current (React) pages hold the lyrics in one or more
+         <div data-lyrics-container="true" class="Lyrics__Container-sc-HASH">
+         elements. The class carries a build-specific hash, so match on the
+         attribute instead. The old <div class="lyrics"> is kept as a fallback. -->
+    <extract>
+      <item container="data-lyrics-container"/>
+    </extract>
     <extract>
       <item tag="&lt;div class=&quot;lyrics&quot;&gt;"/>
     </extract>
     <exclude>
+      <!-- The containers also hold page furniture - contributor count, song title, summary.
+           Genius marks all of it as excluded from selection, so drop those elements whole. -->
+      <item container="data-exclude-from-selection"/>
       <item begin="&lt;!--" end="--&gt;"/>
       <item begin="&lt;a href=" end="&gt;"/>
       <item begin="&lt;/a" end="&gt;"/>

--- a/context/lyrics_providers.xml
+++ b/context/lyrics_providers.xml
@@ -113,8 +113,11 @@
     <invalidIndicator value="we do not have the lyric for this song"/>
     <invalidIndicator value="Your name will be printed as part of the credit when your lyric is approved"/>
   </provider>
-  <provider name="lyricsmania.com" charset="iso-8859-1" url="https://www.lyricsmania.com/{title}_lyrics_{artist}.html">
+  <provider name="lyricsmania.com" charset="utf-8" url="https://www.lyricsmania.com/{title}_lyrics_{artist}.html">
     <urlFormat replace=" _@;&amp;\/&quot;'." with="_"/>
+    <extract>
+      <item tag="&lt;div class=&quot;lyrics-body&quot;&gt;"/>
+    </extract>
     <extract> <!-- new -->
       <item tag="&lt;div id='songlyrics_h' class='dn'&gt;"/>
     </extract>

--- a/context/lyrics_providers.xml
+++ b/context/lyrics_providers.xml
@@ -162,6 +162,12 @@
   <provider name="musixmatch.com" charset="utf-8" url="https://www.musixmatch.com/lyrics/{Artist}/{Title}">
     <urlFormat replace=" _@;\/&quot;'()[]" with="-"/>
     <urlFormat replace="?" with=""/>
+    <!-- The page renders client-side, so the lyrics are in the __NEXT_DATA__ JSON rather than
+         in the markup, and still carry their JSON escapes once pulled out. -->
+    <extract>
+      <item begin="&quot;lyrics&quot;:{&quot;body&quot;:&quot;" end="&quot;,&quot;canEdit&quot;"/>
+      <item unescape="json"/>
+    </extract>
     <extract>
       <item begin="&lt;span id=&quot;lyrics-html&quot;" end="&lt;/span&gt;"/>
     </extract>

--- a/context/lyrics_providers.xml
+++ b/context/lyrics_providers.xml
@@ -129,8 +129,9 @@
   </provider>
   <provider name="lyricsmode.com" charset="utf-8" url="https://www.lyricsmode.com/lyrics/{a}/{artist}/{title}.html">
     <urlFormat replace=" ._@,;&amp;\/&quot;" with="_"/>
-    <!-- Use the tag form rather than begin/end: it retries without the closing '>', so the
-         match survives the extra attributes (class="ui-annotatable") carried by the element. -->
+    <!-- The lyrics moved from <p id="lyrics_text"> to <div id="lyrics_text">. The tag form is
+         used rather than begin/end as it retries without the closing '>', so the match also
+         survives any attributes added to the element later on. -->
     <extract>
       <item tag="&lt;div id=&quot;lyrics_text&quot;&gt;"/>
     </extract>
@@ -143,6 +144,11 @@
     <extract> <!-- new -->
       <item begin="&lt;p id=&quot;lyrics_text&quot;&gt;" end="&lt;/p&gt;"/>
     </extract>
+    <exclude>
+      <!-- The annotation buttons ("Explain", "Request") sit within the lyrics element. They
+           are the only elements carrying this attribute, so drop them whole. -->
+      <item container="data-annotation-type"/>
+    </exclude>
     <invalidIndicator value="Sorry, we have no"/>
   </provider>
   <provider name="lyriki.com" charset="utf-8" url="http://www.lyriki.com/{artist}:{title}">

--- a/context/lyrics_providers.xml
+++ b/context/lyrics_providers.xml
@@ -127,8 +127,16 @@
     </extract>
     <invalidIndicator value="The lyrics you requested is not in our archive yet,"/>
   </provider>
-  <provider name="lyricsmode.com" charset="iso-8859-1" url="http://www.lyricsmode.com/lyrics/{a}/{artist}/{title}.html">
+  <provider name="lyricsmode.com" charset="utf-8" url="https://www.lyricsmode.com/lyrics/{a}/{artist}/{title}.html">
     <urlFormat replace=" ._@,;&amp;\/&quot;" with="_"/>
+    <!-- Use the tag form rather than begin/end: it retries without the closing '>', so the
+         match survives the extra attributes (class="ui-annotatable") carried by the element. -->
+    <extract>
+      <item tag="&lt;div id=&quot;lyrics_text&quot;&gt;"/>
+    </extract>
+    <extract>
+      <item tag="&lt;p id=&quot;lyrics_text&quot;&gt;"/>
+    </extract>
     <extract>
       <item tag="&lt;div id='songlyrics_h' class='dn'&gt;"/>
     </extract>

--- a/context/lyrics_providers.xml
+++ b/context/lyrics_providers.xml
@@ -23,42 +23,6 @@
     </extract>
     <invalidIndicator value="Couldn't find that page."/>
   </provider>
-  <provider name="chartlyrics.com" charset="utf-8" url="http://api.chartlyrics.com/apiv1.asmx/SearchLyricDirect?artist={artist}&amp;song={title}">
-    <urlFormat replace="_@,;&amp;\/&quot;#" with="_"/>
-    <extract>
-      <item tag="&lt;Lyric&gt;"/>
-    </extract>
-    <invalidIndicator value="ERROR"/>
-  </provider>
-  <provider name="darklyrics.com" charset="utf-8" url="http://www.darklyrics.com/lyrics/{artist2}/{album2}.html">
-    <extract> <!-- modified -->
-      <item begin="&lt;h3&gt;&lt;a name=&quot;{track}&quot;&gt;{track}. {Title}&lt;/a&gt;&lt;/h3&gt;&lt;br/&gt;" end="&lt;h3&gt;"/>
-    </extract>
-    <extract> <!-- modified -->
-      <item begin="&lt;h3&gt;&lt;a name=&quot;{track}&quot;&gt;{track}. {Title}&lt;/a&gt;&lt;/h3&gt;&lt;br/&gt;" end="&lt;div class=&quot;thanks&quot;&gt;"/>
-    </extract>
-    <extract> <!-- new -->
-      <item begin="&lt;h3&gt;&lt;a name=&quot;{track}&quot;&gt;{track}. {Title}&lt;/a&gt;&lt;/h3&gt;&lt;br/&gt;" end="&lt;br/&gt;&lt;br/&gt;"/>
-    </extract>
-    <invalidIndicator value="The page you requested was not found on DarkLyrics.com."/>
-  </provider>
-  <provider name="directlyrics.com" charset="utf-8" url="http://www.directlyrics.com/{artist}-{title}-lyrics.html"> <!-- was iso-8859-1 -->
-    <urlFormat replace=" _@,;&amp;\/'&quot;" with="-"/>
-    <urlFormat replace="." with=""/>
-    <extract>
-      <item tag="&lt;div id=&quot;lyricsContent&quot;&gt;"/>
-      <item tag="&lt;p&gt;"/>
-    </extract>
-    <extract> <!-- new -->
-      <item begin="&lt;div class=&quot;lyrics&quot;&gt;" end="&lt;/div&gt;"/>
-    </extract>
-    <exclude>
-      <item begin="&lt;b&gt;" end="&lt;/b&gt;"/>
-    </exclude>
-    <exclude> <!-- new -->
-      <item begin="&lt;script async src=&quot;" end="&lt;/script&gt;&lt;br&gt;"/>
-    </exclude>
-  </provider>
   <provider name="elyrics.net" charset="iso-8859-1" url="https://www.elyrics.net/read/{a}/{artist}-lyrics/{title}-lyrics.html">
     <urlFormat replace=" _@;&amp;\/&quot;" with="-"/>
     <urlFormat replace="'" with="_"/>
@@ -77,27 +41,6 @@
     </exclude>
     <invalidIndicator value="Page not Found"/>
   </provider>
-  <provider name="hindilyrics.net (Bollywood songs)" charset="utf-8" url="http://www.hindilyrics.net/lyrics/of-{Title}.html">
-    <urlFormat replace=" _@;\/&quot;'()[]" with="%20"/>
-    <urlFormat replace="?" with=""/>
-    <extract>
-      <item begin="&lt;div class=nm&gt;Movie&lt;/div&gt;:" end="&lt;/pre&gt;"/>
-    </extract>
-    <exclude>
-      <item begin="&lt;span class=" end="&quot;&gt;"/>
-    </exclude>
-    <invalidIndicator value="Couldn't find that page."/>
-  </provider>
-<!-- Issue #1571
-  <provider name="Encyclopaedia Metallum" charset="utf-8" url="https://www.metal-archives.com/search/ajax-advanced/searching/songs/?songTitle={title}&amp;bandName={artist}&amp;ExactBandMatch=1">
-    <extract>
-      <item url="http://www.metal-archives.com/release/ajax-view-lyrics/id/{id}"/>
-      <item begin="id=\&quot;lyricsLink_" end="&quot;"/>
-    </extract>
-    <invalidIndicator value="&quot;iTotalRecords&quot;: 0"/>
-    <invalidIndicator value="lyrics not available"/>
-  </provider>
--->
   <provider name="letras.mus.br" charset="utf-8" url="https://www.letras.mus.br/winamp.php?musica={title}&amp;artista={artist}">
     <urlFormat replace="_@,;&amp;\/&quot;" with="_"/>
     <urlFormat replace=" " with="+"/>
@@ -154,16 +97,6 @@
     </extract>
     <invalidIndicator value="ERROR"/>
   </provider>
-  <provider name="loudson.gs" charset="utf-8" url="http://www.loudson.gs/{a}/{artist}/{album}/{title}">
-    <urlFormat replace=" _@,;&amp;\/&quot;" with="-"/>
-    <urlFormat replace="." with=""/>
-    <extract>
-      <item tag="&lt;div class=&quot;middle_col_TracksLyrics &quot;&gt;"/>
-    </extract>
-    <extract> <!-- new -->
-      <item tag="&lt;div class=&quot;middle_col_TracksLyrics&quot;&gt;"/>
-    </extract>
-  </provider>
   <provider name="lyrics.com" charset="utf-8" url="https://www.lyrics.com/lyrics/{artist}/{title}.html">
     <urlFormat replace=" _@,;&amp;\/&quot;" with="-"/>
     <urlFormat replace="'." with=""/>
@@ -193,14 +126,6 @@
     </exclude>
     -->
   </provider>
-  <provider name="lyricsdownload.com" charset="utf-8" url="http://www.lyricsdownload.com/{artist}-{title}-lyrics.html">
-    <urlFormat replace=" _@,;&amp;\/&quot;" with="-"/>
-    <urlFormat replace="." with=""/>
-    <extract>
-      <item tag="&lt;div id=&quot;div_customCSS&quot;&gt;"/>
-    </extract>
-    <invalidIndicator value="We haven't lyrics of this song"/>
-  </provider>
   <provider name="lyricsmania.com" charset="iso-8859-1" url="https://www.lyricsmania.com/{title}_lyrics_{artist}.html">
     <urlFormat replace=" _@;&amp;\/&quot;'." with="_"/>
     <extract> <!-- new -->
@@ -222,19 +147,6 @@
     </extract>
     <invalidIndicator value="Sorry, we have no"/>
   </provider>
-  <provider name="lyricsreg.com" charset="iso-8859-1" url="https://www.lyricsreg.com/lyrics/{artist}/{title}/">
-    <urlFormat replace=" _@,;&amp;\/&quot;" with="+"/>
-    <urlFormat replace="'." with=""/>
-    <extract>
-      <item begin="Ringtone to your Cell" end="Ringtone to your Cell"/>
-      <item begin="&lt;div style=&quot;text-align:center;&quot;&gt;" end="&lt;a"/>
-    </extract>
-    <extract> <!-- new -->
-      <item begin="Ringtone to your Cell" end="Ringtone to your Cell"/>
-      <item begin="&lt;/a&gt;&lt;br/&gt;&lt;br/&gt;" end="&lt;a"/>
-    </extract>
-    <invalidIndicator value="Page not Found"/>
-  </provider>
   <provider name="lyriki.com" charset="utf-8" url="http://www.lyriki.com/{artist}:{title}">
     <urlFormat replace=" _@,;&amp;\/&quot;" with="_"/>
     <urlFormat replace="." with=""/>
@@ -242,44 +154,6 @@
       <item begin="&lt;/table&gt;" end="&lt;div class=&quot;printfooter&quot;&gt;"/>
       <item tag="&lt;p&gt;"/>
     </extract>
-  </provider>
-  <!-- broken
-  <provider name="metrolyrics.com" charset="utf-8" url="http://www.metrolyrics.com/{title}-lyrics-{artist}.html">
-    <urlFormat replace=" _@,;&amp;\/&quot;" with="-"/>
-    <urlFormat replace="'." with=""/>
-    <extract>
-      <item tag="&lt;span id=&quot;lyrics&quot;&gt;"/>
-    </extract>
-    <extract>
-      <item tag="&lt;div id=&quot;lyrics&quot;&gt;"/>
-    </extract>
-    <extract>
-      <item tag="&lt;div id=&quot;lyrics-body-text&quot;&gt;"/>
-    </extract>
-    <exclude>
-      <item tag="&lt;h5&gt;"/>
-    </exclude>
-    <invalidIndicator value="These lyrics are missing"/>
-  </provider>
-  -->
-  <provider name="mp3lyrics.org" charset="utf-8" url="http://www.mp3lyrics.org/{a}/{artist}/{title}/">
-    <urlFormat replace=" _@,;&amp;\/&quot;" with="-"/>
-    <urlFormat replace="'." with=""/>
-    <extract>
-      <item tag="&lt;span id=gn_lyricsB&gt;"/>
-    </extract>
-    <extract>
-      <item tag="&lt;div class=&quot;KonaBody&quot; id=&quot;EchoTopic&quot;&gt;"/>
-    </extract>
-    <extract> <!-- new -->
-      <item tag="&lt;div id=&quot;lyrics_text&quot;&gt;"/>
-    </extract>
-    <exclude>
-      <item tag="&lt;font size=2&gt;"/>
-      <item begin="&lt;b&gt;&lt;i&gt;" end="&lt;/u&gt;&lt;/b&gt;:"/>
-      <item begin="&lt;b&gt;Lyrics" end="&lt;/b&gt;"/>
-    </exclude>
-    <invalidIndicator value="Something went wrong"/>
   </provider>
   <provider name="musixmatch.com" charset="utf-8" url="https://www.musixmatch.com/lyrics/{Artist}/{Title}">
     <urlFormat replace=" _@;\/&quot;'()[]" with="-"/>
@@ -327,13 +201,6 @@
     <exclude>
       <item begin="&quot;id-" end="&quot;&gt;"/>
     </exclude>
-  </provider>
-  <provider name="teksty.org" title="{artist} - {title} - tekst" charset="utf-8" url="http://teksty.org/{artist},{title},tekst-piosenki">
-    <urlFormat replace=" _@,;&amp;\/&quot;'" with="-"/>
-    <urlFormat replace="." with=""/>
-    <extract>
-      <item begin="&lt;div class=&quot;songText&quot; id=&quot;songContent&quot;&gt;" end="&lt;/div&gt;"/>
-    </extract>
   </provider>
   <provider name="vagalume.com.br" charset="iso-8859-1" url="http://vagalume.com.br/{artist}/{title}.html">
     <urlFormat replace=" _@,;&amp;\/'&quot;." with="-"/>

--- a/context/lyrics_providers.xml
+++ b/context/lyrics_providers.xml
@@ -113,19 +113,6 @@
     <invalidIndicator value="we do not have the lyric for this song"/>
     <invalidIndicator value="Your name will be printed as part of the credit when your lyric is approved"/>
   </provider>
-  <provider name="lyrics.wikia.com" charset="utf-8" url="https://lyrics.wikia.com/api.php">
-    <!-- These are not used, as mediawiki API is used instead...
-    <urlFormat replace=" _@;\&quot;" with="_"/>
-    <urlFormat replace="?" with="%3F"/>
-    <extract>
-      <item begin="&lt;div class='lyricbox'&gt;" end="&lt;!- -"/>  TODO: This was a comment ( ! - - ) but brakes commentinging out!
-    </extract>
-    <exclude>
-      <item tag="&lt;div class='rtMatcher'&gt;"/>
-      <item tag="&lt;span style=&quot;padding:1em&quot;&gt;"/>
-    </exclude>
-    -->
-  </provider>
   <provider name="lyricsmania.com" charset="iso-8859-1" url="https://www.lyricsmania.com/{title}_lyrics_{artist}.html">
     <urlFormat replace=" _@;&amp;\/&quot;'." with="_"/>
     <extract> <!-- new -->

--- a/context/lyrics_providers.xml
+++ b/context/lyrics_providers.xml
@@ -179,6 +179,13 @@
   <provider name="songlyrics.com" charset="utf-8" url="https://www.songlyrics.com/{artist}/{title}-lyrics/">
     <urlFormat replace=" ._@,;&amp;\/&quot;" with="-"/>
     <urlFormat replace="'" with="_"/>
+    <!-- The lyrics are in the schema.org JSON-LD block rather than in the markup. Within it a
+         double quote is always written as an escape, so the first one following the start of
+         the value is the one closing it, and a quote followed by a brace ends the object. -->
+    <extract>
+      <item begin="&quot;lyrics&quot;:{&quot;@type&quot;:&quot;CreativeWork&quot;,&quot;text&quot;:&quot;" end="&quot;}"/>
+      <item unescape="json"/>
+    </extract>
     <extract>
       <item tag="&lt;p id=&quot;songLyricsDiv&quot; ondragstart=&quot;return false;&quot; onselectstart=&quot;return false;&quot; oncontextmenu=&quot;return false;&quot; class=&quot;songLyricsV14&quot; style=&quot;font-size: 14px;z-index: 9999;position: absolute;left: -6000px;&quot;&gt;"/>
     </extract>

--- a/context/ultimatelyrics.cpp
+++ b/context/ultimatelyrics.cpp
@@ -61,10 +61,19 @@ static UltimateLyricsProvider::Rule parseRule(QXmlStreamReader* reader)
 			if (QLatin1String("item") == reader->name()) {
 				QXmlStreamAttributes attr = reader->attributes();
 				if (attr.hasAttribute("tag")) {
-					ret << UltimateLyricsProvider::RuleItem(attr.value("tag").toString(), QString());
+					ret << UltimateLyricsProvider::RuleItem(UltimateLyricsProvider::RuleItem::XmlTag, attr.value("tag").toString());
 				}
 				else if (attr.hasAttribute("begin")) {
-					ret << UltimateLyricsProvider::RuleItem(attr.value("begin").toString(), attr.value("end").toString());
+					// An item with no 'end' used to be indistinguishable from a 'tag' item, and was
+					// handled as one - keep that behaviour for hand-written provider files.
+					ret << (attr.hasAttribute("end")
+					                ? UltimateLyricsProvider::RuleItem(UltimateLyricsProvider::RuleItem::Range,
+					                                                   attr.value("begin").toString(), attr.value("end").toString())
+					                : UltimateLyricsProvider::RuleItem(UltimateLyricsProvider::RuleItem::XmlTag,
+					                                                   attr.value("begin").toString()));
+				}
+				else if (attr.hasAttribute("container")) {
+					ret << UltimateLyricsProvider::RuleItem(UltimateLyricsProvider::RuleItem::Container, attr.value("container").toString());
 				}
 			}
 			reader->skipCurrentElement();

--- a/context/ultimatelyrics.cpp
+++ b/context/ultimatelyrics.cpp
@@ -75,6 +75,9 @@ static UltimateLyricsProvider::Rule parseRule(QXmlStreamReader* reader)
 				else if (attr.hasAttribute("container")) {
 					ret << UltimateLyricsProvider::RuleItem(UltimateLyricsProvider::RuleItem::Container, attr.value("container").toString());
 				}
+				else if (attr.hasAttribute("unescape")) {
+					ret << UltimateLyricsProvider::RuleItem(UltimateLyricsProvider::RuleItem::Unescape, attr.value("unescape").toString());
+				}
 			}
 			reader->skipCurrentElement();
 		}

--- a/context/ultimatelyricsprovider.cpp
+++ b/context/ultimatelyricsprovider.cpp
@@ -138,6 +138,46 @@ static QString extractXmlTag(const QString& source, const QString& tag)
 	return extract(source, tag, "</" + match.captured(1) + ">", true);
 }
 
+// Decode a JSON string literal. Sites that render client-side (e.g. Musixmatch) embed the
+// lyrics in a JSON blob rather than in markup, so what the extract rules pull out still has
+// its escapes intact.
+static QString jsonUnescape(const QString& source)
+{
+	QString ret;
+	ret.reserve(source.length());
+
+	for (int i = 0; i < source.length(); ++i) {
+		if (QLatin1Char('\\') != source.at(i) || i + 1 >= source.length()) {
+			ret += source.at(i);
+			continue;
+		}
+
+		QChar esc = source.at(++i);
+		switch (esc.toLatin1()) {
+		case 'n': ret += QLatin1Char('\n'); break;
+		case 't': ret += QLatin1Char('\t'); break;
+		case 'r': ret += QLatin1Char('\r'); break;
+		case 'b': ret += QLatin1Char('\b'); break;
+		case 'f': ret += QLatin1Char('\f'); break;
+		case 'u': {
+			bool ok = false;
+			ushort code = i + 4 < source.length() ? source.mid(i + 1, 4).toUShort(&ok, 16) : 0;
+			if (ok) {
+				ret += QChar(code);
+				i += 4;
+			}
+			else {
+				ret += esc;
+			}
+			break;
+		}
+		// Covers \" \\ \/ - and leaves anything unrecognised as-is.
+		default: ret += esc; break;
+		}
+	}
+	return ret;
+}
+
 // Matches the opening tag of an element carrying the named attribute. The attribute must be a
 // whitespace-separated name followed by '=', so that a name is not matched by a longer one that
 // merely starts with it - a word boundary would not do, as '-' ends a word.
@@ -286,6 +326,11 @@ static void applyExtractRule(const UltimateLyricsProvider::Rule& rule, QString& 
 		case UltimateLyricsProvider::RuleItem::Container:
 			content = extractContainers(content, doTagReplace(item.begin, song));
 			break;
+		case UltimateLyricsProvider::RuleItem::Unescape:
+			if (QLatin1String("json") == item.begin) {
+				content = jsonUnescape(content);
+			}
+			break;
 		}
 	}
 }
@@ -302,6 +347,9 @@ static void applyExcludeRule(const UltimateLyricsProvider::Rule& rule, QString& 
 			break;
 		case UltimateLyricsProvider::RuleItem::Container:
 			content = excludeContainers(content, doTagReplace(item.begin, song));
+			break;
+		case UltimateLyricsProvider::RuleItem::Unescape:
+			// Not meaningful as an exclusion - ignored.
 			break;
 		}
 	}

--- a/context/ultimatelyricsprovider.cpp
+++ b/context/ultimatelyricsprovider.cpp
@@ -138,6 +138,116 @@ static QString extractXmlTag(const QString& source, const QString& tag)
 	return extract(source, tag, "</" + match.captured(1) + ">", true);
 }
 
+// Matches the opening tag of an element carrying the named attribute. The attribute must be a
+// whitespace-separated name followed by '=', so that a name is not matched by a longer one that
+// merely starts with it - a word boundary would not do, as '-' ends a word.
+static QRegularExpression containerRegex(const QString& attribute)
+{
+	return QRegularExpression("<(\\w+)\\b[^>]*\\s" + QRegularExpression::escape(attribute) + "\\s*=[^>]*>",
+	                          QRegularExpression::CaseInsensitiveOption);
+}
+
+// Given the opening tag matched by containerRegex(), walks the same tag in and out until the
+// element's own closing tag is reached, so that nested markup does not terminate it early.
+// Sets contentEnd to the start of that closing tag, and elementEnd to just past it.
+static bool findContainerEnd(const QString& source, const QRegularExpressionMatch& open, int& contentEnd, int& elementEnd)
+{
+	QRegularExpression nestRegex("<(/?)" + open.captured(1) + "\\b[^>]*>", QRegularExpression::CaseInsensitiveOption);
+	int scan = open.capturedEnd();
+	int depth = 1;
+
+	while (depth > 0) {
+		auto nest = nestRegex.match(source, scan);
+		if (!nest.hasMatch()) {
+			DBUG << "Failed to find end of container";
+			return false;
+		}
+		if (nest.captured(1).isEmpty()) {
+			++depth;
+		}
+		else if (0 == --depth) {
+			contentEnd = nest.capturedStart();
+			elementEnd = nest.capturedEnd();
+		}
+		scan = nest.capturedEnd();
+	}
+	return true;
+}
+
+// Extract the contents of every element carrying the named attribute. Used for sites (e.g.
+// Genius) that split the lyrics over several containers whose class names are build-specific,
+// and whose contents hold nested markup - so neither a literal tag match nor a naive begin/end
+// pair works.
+static QString extractContainers(const QString& source, const QString& attribute)
+{
+	DBUG << "Looking for containers with" << attribute;
+	QRegularExpression openRegex = containerRegex(attribute);
+	QStringList parts;
+	int pos = 0;
+
+	while (pos < source.length()) {
+		auto open = openRegex.match(source, pos);
+		if (!open.hasMatch()) {
+			break;
+		}
+
+		int contentEnd = -1;
+		int elementEnd = -1;
+		if (!findContainerEnd(source, open, contentEnd, elementEnd)) {
+			break;
+		}
+
+		// Empty containers are used as placeholders around ad slots - skip them, so that
+		// joining does not introduce stray breaks between the sections that do have lyrics.
+		QString content = source.mid(open.capturedEnd(), contentEnd - open.capturedEnd());
+		if (!content.trimmed().isEmpty()) {
+			parts << content;
+		}
+		pos = elementEnd;
+	}
+
+	if (parts.isEmpty()) {
+		DBUG << "Failed to find container";
+		return QString();
+	}
+
+	DBUG << "Found" << parts.length() << "container(s)";
+	return parts.join(QLatin1String("<br/>"));
+}
+
+// Remove every element carrying the named attribute, contents included. Genius marks the
+// page furniture it embeds within the lyrics containers (contributor count, song title,
+// summary) with such an attribute, and it has to go along with the markup it sits in.
+static QString excludeContainers(const QString& source, const QString& attribute)
+{
+	DBUG << "Looking for containers with" << attribute;
+	QRegularExpression openRegex = containerRegex(attribute);
+	QString ret = source;
+	int removed = 0;
+	int pos = 0;
+
+	while (pos < ret.length()) {
+		auto open = openRegex.match(ret, pos);
+		if (!open.hasMatch()) {
+			break;
+		}
+
+		int contentEnd = -1;
+		int elementEnd = -1;
+		if (!findContainerEnd(ret, open, contentEnd, elementEnd)) {
+			break;
+		}
+
+		// Any nested match is removed along with this one, so resume from where it started.
+		ret.remove(open.capturedStart(), elementEnd - open.capturedStart());
+		pos = open.capturedStart();
+		++removed;
+	}
+
+	DBUG << "Removed" << removed << "container(s)";
+	return ret;
+}
+
 static QString exclude(const QString& source, const QString& begin, const QString& end)
 {
 	int beginIdx = source.indexOf(begin, 0, Qt::CaseInsensitive);
@@ -166,11 +276,16 @@ static QString excludeXmlTag(const QString& source, const QString& tag)
 static void applyExtractRule(const UltimateLyricsProvider::Rule& rule, QString& content, const Song& song)
 {
 	for (const UltimateLyricsProvider::RuleItem& item : rule) {
-		if (item.second.isNull()) {
-			content = extractXmlTag(content, doTagReplace(item.first, song));
-		}
-		else {
-			content = extract(content, doTagReplace(item.first, song), doTagReplace(item.second, song));
+		switch (item.type) {
+		case UltimateLyricsProvider::RuleItem::XmlTag:
+			content = extractXmlTag(content, doTagReplace(item.begin, song));
+			break;
+		case UltimateLyricsProvider::RuleItem::Range:
+			content = extract(content, doTagReplace(item.begin, song), doTagReplace(item.end, song));
+			break;
+		case UltimateLyricsProvider::RuleItem::Container:
+			content = extractContainers(content, doTagReplace(item.begin, song));
+			break;
 		}
 	}
 }
@@ -178,11 +293,16 @@ static void applyExtractRule(const UltimateLyricsProvider::Rule& rule, QString& 
 static void applyExcludeRule(const UltimateLyricsProvider::Rule& rule, QString& content, const Song& song)
 {
 	for (const UltimateLyricsProvider::RuleItem& item : rule) {
-		if (item.second.isNull()) {
-			content = excludeXmlTag(content, doTagReplace(item.first, song));
-		}
-		else {
-			content = exclude(content, doTagReplace(item.first, song), doTagReplace(item.second, song));
+		switch (item.type) {
+		case UltimateLyricsProvider::RuleItem::XmlTag:
+			content = excludeXmlTag(content, doTagReplace(item.begin, song));
+			break;
+		case UltimateLyricsProvider::RuleItem::Range:
+			content = exclude(content, doTagReplace(item.begin, song), doTagReplace(item.end, song));
+			break;
+		case UltimateLyricsProvider::RuleItem::Container:
+			content = excludeContainers(content, doTagReplace(item.begin, song));
+			break;
 		}
 	}
 }

--- a/context/ultimatelyricsprovider.cpp
+++ b/context/ultimatelyricsprovider.cpp
@@ -121,7 +121,7 @@ static QString extract(const QString& source, const QString& begin, const QStrin
 	}
 
 	DBUG << "Found match";
-	return source.mid(beginIdx, endIdx - beginIdx - 1);
+	return source.mid(beginIdx, endIdx - beginIdx);
 }
 
 static QRegularExpression xmlTagRegex = QRegularExpression("<(\\w+).*>");

--- a/context/ultimatelyricsprovider.cpp
+++ b/context/ultimatelyricsprovider.cpp
@@ -355,22 +355,6 @@ void UltimateLyricsProvider::fetchInfo(int id, Song metadata, bool removeThe)
 		artistFixed = artistFixed.mid(constThe.length());
 	}
 
-	if (QLatin1String("lyrics.wikia.com") == name) {
-		QUrl url(urlText);
-		QUrlQuery query;
-
-		query.addQueryItem(QLatin1String("artist"), artistFixed);
-		query.addQueryItem(QLatin1String("song"), titleFixed);
-		query.addQueryItem(QLatin1String("func"), QLatin1String("getSong"));
-		query.addQueryItem(QLatin1String("fmt"), QLatin1String("xml"));
-		url.setQuery(query);
-
-		NetworkJob* reply = NetworkAccessManager::self()->get(url);
-		requests[reply] = id;
-		connect(reply, SIGNAL(finished()), this, SLOT(wikiMediaSearchResponse()));
-		return;
-	}
-
 	metadata.priority = removeThe ? 1 : 0;// HACK Use this to indicate if searching without 'The '
 	songs.insert(id, metadata);
 

--- a/context/ultimatelyricsprovider.h
+++ b/context/ultimatelyricsprovider.h
@@ -44,9 +44,10 @@ public:
 
 	struct RuleItem {
 		enum Type {
-			XmlTag,   // <item tag="&lt;div class=&quot;x&quot;&gt;"/>
-			Range,    // <item begin="..." end="..."/>
-			Container // <item container="attribute-name"/>
+			XmlTag,    // <item tag="&lt;div class=&quot;x&quot;&gt;"/>
+			Range,     // <item begin="..." end="..."/>
+			Container, // <item container="attribute-name"/>
+			Unescape   // <item unescape="json"/>
 		};
 
 		RuleItem(Type t, const QString& b, const QString& e = QString())

--- a/context/ultimatelyricsprovider.h
+++ b/context/ultimatelyricsprovider.h
@@ -42,7 +42,20 @@ public:
 	UltimateLyricsProvider();
 	~UltimateLyricsProvider() override;
 
-	typedef QPair<QString, QString> RuleItem;
+	struct RuleItem {
+		enum Type {
+			XmlTag,   // <item tag="&lt;div class=&quot;x&quot;&gt;"/>
+			Range,    // <item begin="..." end="..."/>
+			Container // <item container="attribute-name"/>
+		};
+
+		RuleItem(Type t, const QString& b, const QString& e = QString())
+			: type(t), begin(b), end(e) {}
+
+		Type type;
+		QString begin;
+		QString end;
+	};
 	typedef QList<RuleItem> Rule;
 	typedef QPair<QString, QString> UrlFormat;
 

--- a/gui/settings.cpp
+++ b/gui/settings.cpp
@@ -340,7 +340,7 @@ MPDParseUtils::CueSupport Settings::cueSupport()
 
 QStringList Settings::lyricProviders()
 {
-	return cfg.get("lyricProviders", QStringList() << "azlyrics.com");
+	return cfg.get("lyricProviders", QStringList() << "genius.com");
 }
 
 QStringList Settings::wikipediaLangs()

--- a/gui/settings.cpp
+++ b/gui/settings.cpp
@@ -340,9 +340,7 @@ MPDParseUtils::CueSupport Settings::cueSupport()
 
 QStringList Settings::lyricProviders()
 {
-	return cfg.get("lyricProviders", QStringList() << "azlyrics.com"
-	                                               << "chartlyrics.com"
-	                                               << "lyrics.wikia.com");
+	return cfg.get("lyricProviders", QStringList() << "azlyrics.com");
 }
 
 QStringList Settings::wikipediaLangs()


### PR DESCRIPTION
For quite some time, I noticed that a lot of the providers were broken. So I made an attempt to fix some of them. I also removed those for which the website was clearly defunct or down. Since all previous defaults were broken I set genius as default now, because I didn't know a better option.

Please note that I used Claude Opus 5 to implement these changes. I did try to check the changes as best as I can, but I don't know c++ too well, so feedback is appreciated.

Providers that I checked and fixed explicitely:
- genius.com (which was my main focus)
- lyricsmania.com
- lyricsmode.com
- musixmatch.com
- songlyrics.com

Ones that I checked and were working already:
- letras.mus.br

Still broken. I didn't try to fix, but at least the service is still up:
- azlyrics.com - prohibit extraction, it was already noted in lyrics_providers.xml
- lyriki.com - nothing happened, no idea why

No idea:
- lololyrics.com - couldn't find any song that I have and they have lyrics for
- lyrics.com - I think cantata's side is working, but their side is partially broken. Gives me "No lyrics found" even when searching on the website

The other ones I didn't really try out, because they offered mostly regional stuff.

Edit: I noticed I still had an older email address configured. Fixed that and recommitted all with the proper one. Code is identical.