### PR TITLE
fix/164: update workflows

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -19,7 +19,7 @@ jobs:
     name: 📝 Code Formatting
     steps:
     - name: '🧰 Checkout'
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
     - name: '⚙️ Install clang-format'
       run: |
         sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -32,4 +32,3 @@ jobs:
       with:
         bundle: cantata.flatpak
         manifest-path: dog.unix.cantata.Cantata.yml
-        cache-key: flatpak-builder-${{ github.sha }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: '🚧 Build Cantata'
-      uses: flathub-infra/flatpak-github-actions/flatpak-builder@master
+      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
       with:
         bundle: cantata.flatpak
         manifest-path: dog.unix.cantata.Cantata.yml

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -24,7 +24,7 @@ jobs:
       options: --privileged
     steps:
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: '🚧 Build Cantata'

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -55,7 +55,7 @@ jobs:
         cmake --install build --prefix bundle
     
     - name: '🔏 Sign app bundle'
-      uses: indygreg/apple-code-sign-action@v1.1
+      uses: indygreg/apple-code-sign-action@v1.2
       with:
         input_path: bundle/Cantata.app
         sign: true
@@ -72,7 +72,7 @@ jobs:
         create-dmg --volname "Cantata" --volicon mac/cantata.icns --background mac/dmg/background.png --window-size 600 500 --icon-size 75 --icon "Cantata.app" -25 175 --hide-extension "Cantata.app" --app-drop-link 310 175 package/Cantata.dmg bundle
 
     - name: '🔏 Sign DMG'
-      uses: indygreg/apple-code-sign-action@v1.1
+      uses: indygreg/apple-code-sign-action@v1.2
       with:
         input_path: package/Cantata.dmg
         sign: true

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -25,9 +25,8 @@ jobs:
       run: brew install ninja create-dmg fish
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
-        aqtversion: '==3.1.*'
         version: '6.10'
         host: 'mac'
         target: 'desktop'

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -84,7 +84,7 @@ jobs:
         sign_args: '--for-notarization'
 
     - name: '⏫ Upload Artifact'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: macos-dmg
         path: package/*.dmg

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,9 +30,8 @@ jobs:
       run: brew install ninja
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
-        aqtversion: '==3.1.*'
         version: '6.10'
         host: 'mac'
         target: 'desktop'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,7 +49,7 @@ jobs:
       run: cpack -G DragNDrop -B package --config build/CPackConfig.cmake
 
     - name: '⏫ Upload Artifact'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: macos-dmg
         path: package/*.dmg

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -63,7 +63,7 @@ jobs:
       run: cmake --install build --prefix $PWD/package
 
     - name: '⏫ Upload Artifact'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: windows-standalone-${{ matrix.sys }}
         path: package/

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -27,7 +27,7 @@ jobs:
         fetch-depth: 0
 
     - name: '❄️ Install Nix'
-      uses: cachix/install-nix-action@v30
+      uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 


### PR DESCRIPTION
Update the various dependent workflows to their latest version. Should get rid of Node24 warnings.

Closes #164.