### PR TITLE
git: update nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,32 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {
@@ -36,22 +38,28 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
       }
     },
-    "systems": {
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,66 +1,56 @@
 {
+	description = "Cantata development environment";
+
 	inputs = {
 		nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-		flake-utils.url = "github:numtide/flake-utils";
+
+		flake-parts = {
+			url = "github:hercules-ci/flake-parts";
+			inputs.nixpkgs-lib.follows = "nixpkgs";
+		};
+
+		treefmt-nix = {
+			url = "github:numtide/treefmt-nix";
+			inputs.nixpkgs.follows = "nixpkgs";
+		};
 	};
-	outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system:
+
+	outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; }
+	{
+		systems = [
+			"x86_64-linux"
+			"aarch64-linux"
+			"x86_64-darwin"
+			"aarch64-darwin"
+		];
+
+		perSystem = { config, pkgs, ... }:
 		let
-			name = "cantata";
-			version = "3.5.0";
-			pkgs = import nixpkgs {
-				inherit system;
+			options = if pkgs.stdenv.hostPlatform.isLinux then {} else {
+				withUdisks2 = false;
+				withMtp = false;
+				withLibVlc = false;
+				withDevices = false;
+				withCdioParanoia = false;
+				withMusicbrainz = false;
+				withCddb = false;
 			};
-			isLinux = pkgs.lib.strings.hasSuffix "-linux" system;
-			qtEnv = with pkgs.qt6; env "qt-custom-${qtbase.version}"
-				([
-					qtbase
-					qtconnectivity
-					qthttpserver
-					qtimageformats
-					qtmultimedia
-					qtsvg
-					qttranslations
-					qttools
-				] ++ pkgs.lib.optionals isLinux [
-					qtwayland
-				]);
-			buildInputs = with pkgs; [
-				pkg-config
-				taglib
-				ffmpeg
-				mpg123
-				libebur128
-				avahi
-				zlib
-				qtEnv
-				cmake
-				ninja
-			] ++ lib.optionals isLinux [
-				libGL
-				libGLU
-				libcdio
-				libcdio-paranoia
-				libmusicbrainz5
-				libmtp
-				media-player-info
-				kdePackages.kitemviews
-				kdePackages.karchive
-			];
 		in
 		{
-			packages.default =
-				let
-					inherit (pkgs) stdenv lib;
-				in
-				stdenv.mkDerivation {
-					inherit version buildInputs;
-					src = self;
-					pname = name;
-				};
-			devShells.default = pkgs.mkShell {
-				inherit buildInputs;
-			};
-		}
-	);
+			packages.default = pkgs.callPackage ./nix/package.nix options;
 
+			devShells.default = pkgs.mkShell {
+				inputsFrom = [ config.packages.default ];
+
+				packages = with pkgs; [
+					clang-tools
+					ninja
+				];
+			};
+		};
+
+		imports = [
+			./nix/treefmt.nix
+		];
+	};
 }

--- a/nix/dont-check-for-perl-in-PATH.diff
+++ b/nix/dont-check-for-perl-in-PATH.diff
@@ -1,0 +1,16 @@
+diff --git a/playlists/dynamicplaylists.cpp b/playlists/dynamicplaylists.cpp
+index b85e93b5..3c29f775 100644
+--- a/playlists/dynamicplaylists.cpp
++++ b/playlists/dynamicplaylists.cpp
+@@ -205,11 +205,6 @@ void DynamicPlaylists::start(const QString& name)
+ 		return;
+ 	}
+ 
+-	if (Utils::findExe("perl").isEmpty()) {
+-		emit error(tr("You need to install \"perl\" on your system in order for Cantata's dynamic mode to function."));
+-		return;
+-	}
+-
+ 	QString fName(Utils::dataDir(rulesDir, false) + name + constExtension);
+ 
+ 	if (!QFile::exists(fName)) {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,271 @@
+{
+	stdenv,
+	lib,
+
+	cmake,
+	pkg-config,
+	qt6,
+	kdePackages,
+	perl,
+	zlib,
+
+	withCdda ? false,
+	cdparanoia,
+	withCdioParanoia ? true,
+	libcdio,
+	libcdio-paranoia,
+
+	withMusicbrainz ? true,
+	libmusicbrainz5,
+	withCddb ? true,
+	libcddb,
+
+	withFFmpeg ? true,
+	ffmpeg_6,
+	withMPG123 ? true,
+	mpg123,
+	withReplaygain ? true,
+	libebur128,
+
+	withTaglib ? true,
+	taglib,
+	withHttpStream ? true,
+	gst_all_1,
+	withMtp ? true,
+	libmtp,
+	withDevices ? true,
+	withUdisks2 ? true,
+	udev,
+	withHttpServer ? true,
+	withLibVlc ? true,
+	libvlc,
+	withAvahi ? true,
+	avahi,
+}:
+
+assert withDevices -> withTaglib;
+assert withCdioParanoia -> !withCdda && withDevices;
+assert withCdda -> !withCdioParanoia && withDevices;
+assert withMusicbrainz -> withCdioParanoia || withCdda;
+assert withCddb -> withCdioParanoia || withCdda;
+assert withFFmpeg -> withTaglib && withReplaygain;
+assert withMPG123 -> withTaglib && withReplaygain;
+assert withReplaygain -> withFFmpeg || withMPG123;
+assert withLibVlc -> withHttpStream && stdenv.hostPlatform.isLinux;
+assert withMtp -> withDevices && stdenv.hostPlatform.isLinux;
+assert withUdisks2 -> withDevices && stdenv.hostPlatform.isLinux;
+
+let
+	gst = with gst_all_1; [
+		gstreamer
+		gst-libav
+		gst-plugins-base
+		gst-plugins-good
+		gst-plugins-bad
+	];
+
+	options = [
+		{
+			names = [ "ENABLE_CDIOPARANOIA" ];
+			enable = withCdioParanoia;
+			pkgs = [ libcdio libcdio-paranoia ];
+		}
+		{
+			names = [ "ENABLE_CDPARANOIA" ];
+			enable = withCdda;
+			pkgs = [ cdparanoia ];
+		}
+		{
+			names = [ "ENABLE_MUSICBRAINZ" ];
+			enable = withMusicbrainz;
+			pkgs = [ libmusicbrainz5 ];
+		}
+		{
+			names = [ "ENABLE_CDDB" ];
+			enable = withCddb;
+			pkgs = [ libcddb ];
+		}
+		{
+			names = [ "ENABLE_DEVICES_SUPPORT" ];
+			enable = withDevices;
+			pkgs = [ ];
+		}
+		{
+			names = [ ];
+			enable = withReplaygain;
+			pkgs = [ libebur128 ];
+		}
+		{
+			names = [ "ENABLE_FFMPEG" ];
+			enable = withFFmpeg;
+			pkgs = [ ffmpeg_6 ];
+		}
+		{
+			names = [ "ENABLE_MPG123" ];
+			enable = withMPG123;
+			pkgs = [ mpg123 ];
+		}
+		{
+			names = [ "ENABLE_HTTP_SERVER" ];
+			enable = withHttpServer;
+			pkgs = [ ];
+		}
+		{
+			names = [ "ENABLE_HTTP_STREAM_PLAYBACK" ];
+			enable = withHttpStream;
+			pkgs = lib.optionals (!withLibVlc) [ qt6.qtmultimedia ];
+		}
+		{
+			names = [ "ENABLE_LIBVLC" ];
+			enable = withLibVlc;
+			pkgs = [ libvlc ];
+		}
+		{
+			names = [ "ENABLE_MTP" ];
+			enable = withMtp;
+			pkgs = [ libmtp ];
+		}
+		{
+			names = [ "ENABLE_TAGLIB" ];
+			enable = withTaglib;
+			pkgs = [ taglib ];
+		}
+		{
+			names = [ "ENABLE_UDISKS2" ];
+			enable = withUdisks2;
+			pkgs = [ udev ];
+		}
+		{
+			names = [ "ENABLE_AVAHI" ];
+			enable = withAvahi;
+			pkgs = [ avahi ];
+		}
+	];
+in
+stdenv.mkDerivation (final: {
+	pname = "cantata";
+	version = "3.5.0";
+	src = ../.;
+
+	patches = [
+		./dont-check-for-perl-in-PATH.diff
+	];
+
+	postPatch = ''
+patchShebangs playlists
+'';
+
+	buildInputs = [
+		qt6.qtbase
+		qt6.qtsvg
+		(perl.withPackages (ppkgs: with ppkgs; [ URI ]))
+		zlib
+	]
+	++ lib.flatten (builtins.catAttrs "pkgs" (builtins.filter (e: e.enable) options))
+	++ lib.optionals stdenv.hostPlatform.isLinux [
+		qt6.qtwayland
+		kdePackages.karchive
+		kdePackages.kitemviews
+	];
+
+	nativeBuildInputs = [
+		cmake
+		pkg-config
+		qt6.qttools
+		qt6.wrapQtAppsHook
+	];
+
+	cmakeFlags = [
+		(lib.cmakeBool "BUNDLED_KCATEGORIZEDVIEW" (!stdenv.hostPlatform.isLinux))
+		(lib.cmakeBool "BUNDLED_KARCHIVE" (!stdenv.hostPlatform.isLinux))
+		(lib.cmakeBool "BUNDLED_FONTAWESOME" true)
+	] ++ lib.flatten (map (e: map (f: lib.cmakeBool f e.enable) e.names) options);
+
+	qtWrapperArgs = lib.optionals (withHttpStream && !withLibVlc) [
+		"--prefix GST_PLUGIN_PATH : ${lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" gst}"
+	];
+
+	dontWrapQtApps = stdenv.hostPlatform.isDarwin;
+
+	postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+mkdir -p $out/Applications $out/bin
+mv $out/Cantata.app $out/Applications/Cantata.app
+
+makeBinaryWrapper $out/Applications/Cantata.app/Contents/MacOS/Cantata $out/bin/cantata
+'';
+
+	preFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+wrapQtApp "$out/Applications/Cantata.app/Contents/MacOS/Cantata"
+'';
+
+	meta = {
+		description = "Graphical client for MPD";
+		mainProgram = "cantata";
+		homepage = "https://github.com/nullobsi/cantata";
+		license = lib.licenses.gpl3Only;
+		platforms = lib.platforms.unix;
+	};
+})
+	
+
+
+/*
+		let
+			name = "cantata";
+			version = "3.5.0";
+			pkgs = import nixpkgs {
+				inherit system;
+			};
+			isLinux = pkgs.lib.strings.hasSuffix "-linux" system;
+			qtEnv = with pkgs.qt6; env "qt-custom-${qtbase.version}"
+				([
+					qtbase
+					qtconnectivity
+					qthttpserver
+					qtimageformats
+					qtmultimedia
+					qtsvg
+					qttranslations
+					qttools
+				] ++ pkgs.lib.optionals isLinux [
+					qtwayland
+				]);
+			buildInputs = with pkgs; [
+				pkg-config
+				taglib
+				ffmpeg
+				mpg123
+				libebur128
+				avahi
+				zlib
+				qtEnv
+				cmake
+				ninja
+			] ++ lib.optionals isLinux [
+				libGL
+				libGLU
+				libcdio
+				libcdio-paranoia
+				libmusicbrainz5
+				libmtp
+				media-player-info
+				kdePackages.kitemviews
+				kdePackages.karchive
+			];
+		in
+		{
+			packages.default =
+				let
+					inherit (pkgs) stdenv lib;
+				in
+				stdenv.mkDerivation {
+					inherit version buildInputs;
+					src = self;
+					pname = name;
+				};
+			devShells.default = pkgs.mkShell {
+				inherit buildInputs;
+			};
+		}
+	);
+	*/

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,0 +1,19 @@
+{ inputs, ... }:
+
+{
+	imports = [ inputs.treefmt-nix.flakeModule ];
+
+	perSystem =
+		{ pkgs, ... }:
+		{
+			treefmt = {
+				projectRootFile = "flake.nix";
+
+				programs.nixfmt.enable = true;
+				programs.nixfmt.package = pkgs.nixfmt;
+
+				programs.clang-format.enable = true;
+				programs.clang-format.package = pkgs.clang-tools;
+			};
+		};
+}


### PR DESCRIPTION
use flake-parts instead of flake-utils, and introduce a treefmt module along with a new Nix package based on the NixOS package.